### PR TITLE
Use fennel pickling

### DIFF
--- a/fennel/feature/feature.py
+++ b/fennel/feature/feature.py
@@ -1,15 +1,14 @@
 import ast
 import functools
 import inspect
-import textwrap
 from typing import *
 
-import cloudpickle
 import pandas as pd
 
 import fennel.gen.feature_pb2 as feature_proto
 from fennel.gen.services_pb2_grpc import FennelFeatureStoreStub
 from fennel.lib.schema import Schema
+from fennel.utils import fennel_pickle
 
 
 def aggregate_lookup(agg_name: str, **kwargs):
@@ -62,48 +61,6 @@ class FeatureExtractTransformer(ast.NodeTransformer):
         return node
 
 
-# Takes the list of aggregates that this feature depends upon as dictionary of aggregate to aggregate name
-# and the list of feature names that this feature depends upon.
-def _modify_feature_extract(
-    func, agg2name: Dict[str, str], feature2name: List[Any]
-):
-    if hasattr(func, "wrapped_function"):
-        feature_func = func.wrapped_function
-    else:
-        feature_func = func
-    function_source_code = textwrap.dedent(inspect.getsource(feature_func))
-    tree = ast.parse(function_source_code)
-    new_tree = FeatureExtractTransformer(agg2name, feature2name).visit(tree)
-    decorators = []
-    for decorator in new_tree.body[0].decorator_list:
-        if isinstance(decorator, ast.Call) and decorator.func.id in (
-            "feature",
-            "feature_pack",
-        ):
-            decorators.append(
-                ast.Call(decorator.func, decorator.args, decorator.keywords)
-            )
-    new_tree.body[0].decorator_list = decorators
-    ast.fix_missing_locations(new_tree)
-    ast.copy_location(new_tree.body[0], tree)
-    code = compile(tree, inspect.getfile(feature_func), "exec")
-    tmp_namespace = {}
-    if hasattr(func, "namespace"):
-        namespace = func.namespace
-    else:
-        namespace = func.__globals__
-    if hasattr(func, "func_name"):
-        func_name = func.func_name
-    else:
-        func_name = func.__name__
-    for k, v in namespace.items():
-        if k == func_name:
-            continue
-        tmp_namespace[k] = v
-    exec(code, tmp_namespace)
-    return tmp_namespace[func_name], function_source_code
-
-
 def feature(
     name: str = None,
     version: int = 1,
@@ -149,45 +106,21 @@ def feature(
 
         setattr(ret, "validate", validate)
 
-        def mod_extract(*args, **kwargs) -> pd.DataFrame:
-            return func(*args, **kwargs)
-
-        setattr(ret, "mod_extract", mod_extract)
-
         # Directly called only for testing. Else the modded function feature_extract is called in the backend.
         def extract(*args, **kwargs) -> pd.DataFrame:
-            agg2name = {
-                agg.__name__: agg.name for agg in ret.depends_on_aggregates
-            }
-            feature2name = {
-                f.func_def_name: f.name for f in ret.depends_on_features
-            }
-            mod_feature_func, _ = _modify_feature_extract(
-                func, agg2name, feature2name
-            )
-            return mod_feature_func(*args, **kwargs)
+            return func(*args, **kwargs)
 
         setattr(ret, "extract", extract)
 
         @functools.wraps(func)
         def register(stub: FennelFeatureStoreStub):
-            agg2name = {
-                agg.__name__: agg.name for agg in ret.depends_on_aggregates
-            }
-            feature2name = {
-                f.func_def_name: f.name for f in ret.depends_on_features
-            }
-            mod_feature_func, function_source_code = _modify_feature_extract(
-                func, agg2name, feature2name
-            )
-
             req = feature_proto.CreateFeatureRequest(
                 name=name,
                 version=version,
                 mode=mode,
                 schema=schema.to_proto(),
-                function=cloudpickle.dumps(mod_feature_func),
-                function_source_code=function_source_code,
+                function=fennel_pickle(func),
+                function_source_code=inspect.getsource(func),
                 type=feature_proto.FeatureDefType.FEATURE,
             )
             req.depends_on_features.extend(
@@ -257,19 +190,17 @@ def feature_pack(
 
         @functools.wraps(func)
         def register(stub: FennelFeatureStoreStub):
-            agg2name = {
-                agg.__name__: agg.name for agg in ret.depends_on_aggregates
-            }
-            new_function, function_source_code = _modify_feature_extract(
-                func, agg2name, ret.depends_on_features
+            print(
+                "Going to dump func"
+                "--------------------------------------------------------"
             )
             req = feature_proto.CreateFeatureRequest(
                 name=name,
                 version=version,
                 mode=mode,
                 schema=schema.to_proto(),
-                function=cloudpickle.dumps(new_function),
-                function_source_code=function_source_code,
+                function=fennel_pickle(func),
+                function_source_code=inspect.getsource(func),
                 type=feature_proto.FeatureDefType.FEATURE_PACK,
             )
             req.depends_on_features.extend(

--- a/fennel/gen/aggregate_pb2.py
+++ b/fennel/gen/aggregate_pb2.py
@@ -14,25 +14,25 @@ _sym_db = _symbol_database.Default()
 import fennel.gen.schema_pb2 as schema__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0f\x61ggregate.proto\x12\x0c\x66\x65nnel.proto\x1a\x0cschema.proto\"\xf0\x01\n\x16\x43reateAggregateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04mode\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\r\x12\x0e\n\x06stream\x18\x04 \x01(\t\x12\x0f\n\x07\x61gg_cls\x18\x06 \x01(\x0c\x12\x1c\n\x14\x66unction_source_code\x18\x07 \x01(\t\x12\x33\n\x0e\x61ggregate_type\x18\x08 \x01(\x0b\x32\x1b.fennel.proto.AggregateType\x12\x0f\n\x07windows\x18\t \x03(\x05\x12$\n\x06schema\x18\n \x01(\x0b\x32\x14.fennel.proto.Schema\"\xc6\x02\n\rAggregateType\x12\x31\n\x08\x66unction\x18\x01 \x01(\x0e\x32\x1f.fennel.proto.AggregateFunction\x12\x12\n\nkey_fields\x18\x02 \x03(\t\x12\x17\n\x0ftimestamp_field\x18\x03 \x01(\t\x12\x33\n\rwindow_config\x18\x04 \x01(\x0b\x32\x1a.fennel.proto.WindowConfigH\x00\x12\x38\n\x10key_value_config\x18\x05 \x01(\x0b\x32\x1c.fennel.proto.KeyValueConfigH\x00\x12/\n\x0btopk_config\x18\x06 \x01(\x0b\x32\x18.fennel.proto.TopKConfigH\x00\x12+\n\tcf_config\x18\x07 \x01(\x0b\x32\x16.fennel.proto.CFConfigH\x00\x42\x08\n\x06\x43onfig\"4\n\x0cWindowConfig\x12\x0f\n\x07windows\x18\x01 \x03(\x05\x12\x13\n\x0bvalue_field\x18\x02 \x01(\t\"%\n\x0eKeyValueConfig\x12\x13\n\x0bvalue_field\x18\x02 \x01(\t\"A\n\nTopKConfig\x12\t\n\x01k\x18\x01 \x01(\x05\x12\x13\n\x0bitem_fields\x18\x02 \x03(\t\x12\x13\n\x0bscore_field\x18\x03 \x01(\t\"C\n\x08\x43\x46\x43onfig\x12\t\n\x01k\x18\x01 \x01(\x05\x12\x16\n\x0e\x63ontext_fields\x18\x02 \x03(\t\x12\x14\n\x0cweight_field\x18\x03 \x01(\t*m\n\x11\x41ggregateFunction\x12\x07\n\x03SUM\x10\x00\x12\x07\n\x03\x41VG\x10\x01\x12\t\n\x05\x43OUNT\x10\x02\x12\x07\n\x03MIN\x10\x03\x12\x07\n\x03MAX\x10\x04\x12\x08\n\x04RATE\x10\x05\x12\r\n\tKEY_VALUE\x10\x06\x12\x08\n\x04TOPK\x10\x07\x12\x06\n\x02\x43\x46\x10\x08\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0f\x61ggregate.proto\x12\x0c\x66\x65nnel.proto\x1a\x0cschema.proto\"\x8f\x02\n\x16\x43reateAggregateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04mode\x18\x02 \x01(\t\x12\x0f\n\x07version\x18\x03 \x01(\r\x12\x0e\n\x06stream\x18\x04 \x01(\t\x12\x0f\n\x07\x61gg_cls\x18\x06 \x01(\x0c\x12\x1c\n\x14\x66unction_source_code\x18\x07 \x01(\t\x12\x33\n\x0e\x61ggregate_type\x18\x08 \x01(\x0b\x32\x1b.fennel.proto.AggregateType\x12\x0f\n\x07windows\x18\t \x03(\x05\x12$\n\x06schema\x18\n \x01(\x0b\x32\x14.fennel.proto.Schema\x12\x1d\n\x15\x64\x65pends_on_aggregates\x18\x0b \x03(\t\"\xc6\x02\n\rAggregateType\x12\x31\n\x08\x66unction\x18\x01 \x01(\x0e\x32\x1f.fennel.proto.AggregateFunction\x12\x12\n\nkey_fields\x18\x02 \x03(\t\x12\x17\n\x0ftimestamp_field\x18\x03 \x01(\t\x12\x33\n\rwindow_config\x18\x04 \x01(\x0b\x32\x1a.fennel.proto.WindowConfigH\x00\x12\x38\n\x10key_value_config\x18\x05 \x01(\x0b\x32\x1c.fennel.proto.KeyValueConfigH\x00\x12/\n\x0btopk_config\x18\x06 \x01(\x0b\x32\x18.fennel.proto.TopKConfigH\x00\x12+\n\tcf_config\x18\x07 \x01(\x0b\x32\x16.fennel.proto.CFConfigH\x00\x42\x08\n\x06\x43onfig\"4\n\x0cWindowConfig\x12\x0f\n\x07windows\x18\x01 \x03(\x05\x12\x13\n\x0bvalue_field\x18\x02 \x01(\t\"%\n\x0eKeyValueConfig\x12\x13\n\x0bvalue_field\x18\x02 \x01(\t\"A\n\nTopKConfig\x12\t\n\x01k\x18\x01 \x01(\x05\x12\x13\n\x0bitem_fields\x18\x02 \x03(\t\x12\x13\n\x0bscore_field\x18\x03 \x01(\t\"C\n\x08\x43\x46\x43onfig\x12\t\n\x01k\x18\x01 \x01(\x05\x12\x16\n\x0e\x63ontext_fields\x18\x02 \x03(\t\x12\x14\n\x0cweight_field\x18\x03 \x01(\t*m\n\x11\x41ggregateFunction\x12\x07\n\x03SUM\x10\x00\x12\x07\n\x03\x41VG\x10\x01\x12\t\n\x05\x43OUNT\x10\x02\x12\x07\n\x03MIN\x10\x03\x12\x07\n\x03MAX\x10\x04\x12\x08\n\x04RATE\x10\x05\x12\r\n\tKEY_VALUE\x10\x06\x12\x08\n\x04TOPK\x10\x07\x12\x06\n\x02\x43\x46\x10\x08\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'aggregate_pb2', globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _AGGREGATEFUNCTION._serialized_start=848
-  _AGGREGATEFUNCTION._serialized_end=957
+  _AGGREGATEFUNCTION._serialized_start=879
+  _AGGREGATEFUNCTION._serialized_end=988
   _CREATEAGGREGATEREQUEST._serialized_start=48
-  _CREATEAGGREGATEREQUEST._serialized_end=288
-  _AGGREGATETYPE._serialized_start=291
-  _AGGREGATETYPE._serialized_end=617
-  _WINDOWCONFIG._serialized_start=619
-  _WINDOWCONFIG._serialized_end=671
-  _KEYVALUECONFIG._serialized_start=673
-  _KEYVALUECONFIG._serialized_end=710
-  _TOPKCONFIG._serialized_start=712
-  _TOPKCONFIG._serialized_end=777
-  _CFCONFIG._serialized_start=779
-  _CFCONFIG._serialized_end=846
+  _CREATEAGGREGATEREQUEST._serialized_end=319
+  _AGGREGATETYPE._serialized_start=322
+  _AGGREGATETYPE._serialized_end=648
+  _WINDOWCONFIG._serialized_start=650
+  _WINDOWCONFIG._serialized_end=702
+  _KEYVALUECONFIG._serialized_start=704
+  _KEYVALUECONFIG._serialized_end=741
+  _TOPKCONFIG._serialized_start=743
+  _TOPKCONFIG._serialized_end=808
+  _CFCONFIG._serialized_start=810
+  _CFCONFIG._serialized_end=877
 # @@protoc_insertion_point(module_scope)

--- a/fennel/proto/aggregate.proto
+++ b/fennel/proto/aggregate.proto
@@ -26,6 +26,7 @@ message CreateAggregateRequest {
   AggregateType aggregate_type = 8;
   repeated int32 windows = 9;
   Schema schema = 10;
+  repeated string depends_on_aggregates = 11;
 }
 
 message AggregateType {

--- a/fennel/utils.py
+++ b/fennel/utils.py
@@ -1,34 +1,37 @@
+from typing import Any
+
+import cloudpickle
+
 from fennel.gen.status_pb2 import Status
-
-
-#
-# class Singleton(object):
-#     """Use to create a singleton"""
-#
-#     def __new__(cls, *args, **kwds):
-#         it_id = "__it__"
-#         # getattr will dip into base classes, so __dict__ must be used
-#         it = cls.__dict__.get(it_id, None)
-#         if it is not None:
-#             return it
-#         it = object.__new__(cls)
-#         setattr(cls, it_id, it)
-#         it.init(*args, **kwds)
-#         return it
-#
-#     @classmethod
-#     def instance(cls):
-#         if not hasattr(cls, "__it__"):
-#             raise Exception(
-#                 f"Singleton instance {cls.__name__} not initialized"
-#             )
-#         return getattr(cls, "__it__")
-#
-#     def init(self, *args, **kwds):
-#         pass
 
 
 def check_response(response: Status):
     """Check the response from the server and raise an exception if the response is not OK"""
     if response.code != 200:
         raise Exception(response.message)
+
+
+def del_namespace(obj):
+    if not hasattr(obj, "__dict__"):
+        return
+    if "namespace" in obj.__dict__:
+        obj.__dict__.pop("namespace")
+    for k, v in obj.__dict__.items():
+        if isinstance(v, dict):
+            for k1, v1 in v.items():
+                del_namespace(v1)
+        elif isinstance(v, list):
+            for v1 in v:
+                del_namespace(v1)
+        else:
+            del_namespace(v)
+
+
+def fennel_pickle(obj: Any) -> bytes:
+    """Pickle an object using the Fennel protocol"""
+    del_namespace(obj)
+    return cloudpickle.dumps(obj)
+
+
+def square(x):
+    return x * x

--- a/fennel/workspace/e2e_test.py
+++ b/fennel/workspace/e2e_test.py
@@ -342,7 +342,7 @@ def test_client_AggregatePreprocess(create_test_workspace):
     workspace = create_test_workspace(
         {UserGenderKVAgg: pd.Series(["male", "female", "male"])}
     )
-    workspace.register_aggregates(UserGenderKVAgg)  # GenderLikeCountWithKVAgg)
+    workspace.register_aggregates(UserGenderKVAgg, GenderLikeCountWithKVAgg)
     now = pd.Timestamp.now()
     df = pd.DataFrame(
         {
@@ -372,8 +372,8 @@ def test_client_AggregatePreprocess(create_test_workspace):
     aggregates=[UserLikeCount],
 )
 def user_like_count_3days(uids: pd.Series) -> pd.Series:
-    day7, day28 = UserLikeCount.lookup(
-        uids=uids, window=[windows.DAY, windows.WEEK]
+    day7, day28 = aggregate_lookup(
+        "TestUserLikeCount", uids=uids, window=[windows.DAY, windows.WEEK]
     )
     day7 = day7.apply(lambda x: x * x)
     return day7
@@ -402,8 +402,8 @@ def test_Feature(create_test_workspace):
 )
 def user_like_count_3days_square_random(uids: pd.Series) -> pd.Series:
     user_count_features = user_like_count_3days.extract(uids=uids)
-    day7, day28 = UserLikeCount.lookup(
-        uids=uids, window=[windows.DAY, windows.WEEK]
+    day7, day28 = aggregate_lookup(
+        "TestUserLikeCount", uids=uids, window=[windows.DAY, windows.WEEK]
     )
     day7_sq = day7.apply(lambda x: x * x)
     user_count_features_sq = user_count_features.apply(lambda x: x * x)


### PR DESCRIPTION
Cloudpickle recursively finds all objects that need to be pickled from a function or a class. For eg it uses - https://github.com/cloudpipe/cloudpickle/blob/master/cloudpickle/cloudpickle_fast.py#L573 to pickle the function. 

While doing so, the namespace dictionary also gets pickled which contains literally everything under the sun. Removing it before pickling so that users don't run into the vague error of - TypeError: cannot pickle 'EncodedFile' object