### PR TITLE
client testing: use utcnow() instead of pd.timestamp.now

### DIFF
--- a/fennel/test_lib/mock_client.py
+++ b/fennel/test_lib/mock_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 import hashlib
 import json
 import os
@@ -286,7 +287,7 @@ class MockClient(Client):
         extractors = get_extractor_order(
             input_feature_list, output_feature_list, self.extractors
         )
-        timestamps = pd.Series([pd.Timestamp.now()] * len(input_dataframe))
+        timestamps = pd.Series([datetime.utcnow()] * len(input_dataframe))
         return self._run_extractors(
             extractors, input_dataframe, output_feature_list, timestamps
         )


### PR DESCRIPTION
- pd.timestamp.now() returns the local timestamp. In a lot of test cases, we use datetime.utctime(). This causes these test cases to fail as they are attempting to lookup data at a wrong timestamp. 
- Our CI did not catch this mostly because we use Github dedicated runners and they are probably running in utc timezone. I am not 100% sure but confident that's the case