### PR TITLE
client: add support for passing in a session object

### DIFF
--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -24,11 +24,14 @@ _DEFAULT_TIMEOUT = 30
 
 
 class Client:
-    def __init__(self, url: str):
+    def __init__(self, url: str, http_session: Optional[Any] = None):
         self.url = url
         self.to_register: Set[str] = set()
         self.to_register_objects: List[Union[Dataset, Featureset]] = []
-        self.http = self._get_session()
+        if http_session:
+            self.http = http_session
+        else:
+            self.http = self._get_session()
 
     def add(self, obj: Union[Dataset, Featureset]):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.7.1"
+version = "0.7.2"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [


### PR DESCRIPTION
To connect to an authenticated fennel endpoint, users can do the following:
```py
session = requests.session()
session.auth = ("username", "password")
c = Client("http://foo.bar", session)
```