### PR TITLE
auth: add support for passing auth token with http and grpc requests

### DIFF
--- a/fennel/test_lib/local_client.py
+++ b/fennel/test_lib/local_client.py
@@ -5,10 +5,8 @@ from fennel.client import Client
 
 
 class LocalClient(Client):
-    def __init__(
-        self, grpc_url: str, rest_url: str, http_session: Optional[Any] = None
-    ):
-        Client.__init__(self, grpc_url, http_session)
+    def __init__(self, grpc_url: str, rest_url: str):
+        Client.__init__(self, grpc_url)
         self.rest_url = rest_url
 
     def _url(self, path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.12.0"
+version = "0.13.0"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [


### PR DESCRIPTION
When the auth token doesn't match what the server expects, we see the following error:
```
E           grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
E           	status = StatusCode.UNAUTHENTICATED
E           	details = "Authentication failed"
E           	debug_error_string = "UNKNOWN:Error received from peer ipv4:127.0.0.1:23104 {grpc_message:"Authentication failed", grpc_status:16, created_time:"2023-04-26T00:22:37.9974-07:00"}"
E           >
```