### PR TITLE
Fix docs build trigger action

### DIFF
--- a/.github/workflows/trigger-build.yml
+++ b/.github/workflows/trigger-build.yml
@@ -72,6 +72,6 @@ jobs:
       # Publish to Vercel
       #----------------------------------------------
       - name: Notify Vercel of new content
-        uses: wei/curl@v1
+        uses: sozo-design/curl@v1.0.1
         with:
           args: -X POST ${{ secrets.BUILD_TRIGGER_URL }}


### PR DESCRIPTION
Action started failing as `wei/curl` could no longer be found. (The repo appears to be gone from Github, and no longer shows up at it's original URL)

Potentially it was made private or removed 

PR adds a new action to perform the POST request to Vercel and trigger a build