### PR TITLE
lambda function: Fix lambda function extraction for python 3.11

### DIFF
--- a/fennel/lib/to_proto/test_source_code.py
+++ b/fennel/lib/to_proto/test_source_code.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Optional, List
 
 import pandas as pd
+from typing import Optional, List
 
 from fennel.datasets import dataset, field, Dataset, pipeline
 from fennel.featuresets import featureset, feature, extractor
@@ -192,17 +192,17 @@ def get_lambda(x):
 # fmt: off
 def test_lambda_source_code_gen():
     a1 = lambda x: x + 1  # type: ignore # noqa: E731
-    expected_source_code = """lambda x: x + 1  # type: ignore # noqa: E731"""
+    expected_source_code = """lambda x: x + 1"""
     assert expected_source_code == lambda_to_python_regular_func(a1)
 
     a2 = lambda x, y: x + y  # type: ignore # noqa: E731
-    expected_source_code = """lambda x, y: x + y  # type: ignore # noqa: E731"""
+    expected_source_code = """lambda x, y: x + y"""
     assert expected_source_code == lambda_to_python_regular_func(a2)
 
     y1 = get_lambda(lambda x: x * (x + 2) + x + 4)
 
     y2 = get_lambda(get_lambda(get_lambda(get_lambda(get_lambda(lambda x:
-                                                                x * x + 1 + 2 * 3 + 4)))))
+    x * x + 1 + 2 * 3 + 4)))))
     expected_source_code = """lambda x: x * x + 1 + 2 * 3 + 4"""
     assert expected_source_code == lambda_to_python_regular_func(y2)
 
@@ -252,11 +252,26 @@ def extract_location_index(df: pd.DataFrame, index_col: str,
     })
 
 
+def fill_empty(df: pd.DataFrame, col: str):
+    cols = list(col)
+    df = df.fillna(value={col: '' for col in cols})
+    return df
+
+
+def get_lambda2(x1, x2):
+    return x1
+
+
 def test_longer_lambda_source_code_gen():
+    schema = {}
+    lambda_func = get_lambda2(lambda df: fill_empty(df, 'device'), schema)
+    expected_source_code = """lambda df: fill_empty(df, 'device')"""
+    assert expected_source_code == lambda_to_python_regular_func(lambda_func)
+
     lambda_func = get_lambda(
         lambda x: extract_keys(x, json_col='json_payload',
-                               keys=['user_id', 'latitude', 'longitude', 'token'],
-                               values=["a", "b", "c", "d"]),
+            keys=['user_id', 'latitude', 'longitude', 'token'],
+            values=["a", "b", "c", "d"]),
     )
     expected_source_code = """lambda x: extract_keys(x, json_col='json_payload', keys=['user_id', 'latitude', 'longitude', 'token'], values=["a", "b", "c", "d"])"""
     assert expected_source_code == lambda_to_python_regular_func(lambda_func)
@@ -264,16 +279,16 @@ def test_longer_lambda_source_code_gen():
     # More complex multi-line lambda
     lambda_func = get_lambda(
         get_lambda(lambda x: extract_keys(x, json_col='json_payload',
-                                          keys=['user_id', 'latitude', 'longitude', 'token'],
-                                          values=["a", "b", "c", "d"])))
+            keys=['user_id', 'latitude', 'longitude', 'token'],
+            values=["a", "b", "c", "d"])))
     expected_source_code = """lambda x: extract_keys(x, json_col='json_payload', keys=['user_id', 'latitude', 'longitude', 'token'], values=["a", "b", "c", "d"])"""
     assert expected_source_code == lambda_to_python_regular_func(lambda_func)
 
     # Create a complex lambda with a lambda inside
     lambda_func = get_lambda(
         lambda x: extract_location_index(x, index_col='location_index',
-                                         latitude_col='latitude', longitude_col='longitude',
-                                         resolution=lambda x: x + 1)
+            latitude_col='latitude', longitude_col='longitude',
+            resolution=lambda x: x + 1)
     )
     expected_source_code = """lambda x: extract_location_index(x, index_col='location_index', latitude_col='latitude', longitude_col='longitude', resolution=lambda x: x + 1)"""
     assert expected_source_code == lambda_to_python_regular_func(lambda_func)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.16.5"
+version = "0.16.6"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
We earlier used byte matching to find the lambda text, but now use a more reliable source of information i.e the offsets in the lambda ast node