### PR TITLE
Fix docsearch re-indexing action

### DIFF
--- a/docs/algolia.config.json
+++ b/docs/algolia.config.json
@@ -1,10 +1,10 @@
 {
 	"index_name": "docsearch_prod",
 	"start_urls": [
-		"https://docs.fennel.ai"
+		"https://fennel.ai/docs"
 	],
 	"sitemap_urls": [
-		"https://docs.fennel.ai/sitemap.xml"
+		"https://fennel.ai/docs/sitemap.xml"
 	],
 	"selectors": {
 		"lvl0": {


### PR DESCRIPTION
Tweak the algolia docsearch scraper config to change `docs.fennel.ai` => `fennel.ai/docs` 