### PR TITLE
s3: allow creating source without credentials

### DIFF
--- a/docs/pages/api-reference/sources.md
+++ b/docs/pages/api-reference/sources.md
@@ -10,7 +10,7 @@ Here is the description of all the external sources supported by Fennel and how 
 
 ### Webhook
 
-The Webhook source operates on a push-based mechanism, making it convenient for sending data to Fennel. 
+The Webhook source operates on a push-based mechanism, making it convenient for sending data to Fennel.
 There are two options for pushing data into Fennel: utilizing the Fennel Python SDK or employing the REST API.
 
 The following fields need to be specified:
@@ -35,45 +35,55 @@ The following fields need to be specified:
 4. **`db_name`** - The database name.
 5. **`username`** - The username which is used to access the database.
 6. **`password`** - The password associated with the username.
-7. **`jdbc_params`** - Additional properties to pass to the JDBC URL string when connecting to the database formatted as `key=value` pairs separated by the symbol `&`. (example: `key1=value1&key2=value2&key3=value3`).
+7. **`jdbc_params`** - Additional properties to pass to the JDBC URL string when connecting to the database formatted
+   as `key=value` pairs separated by the symbol `&`. (example: `key1=value1&key2=value2&key3=value3`).
 
 <pre snippet="api-reference/source#mysql_source"></pre>
 
 :::warning
-If you see a `Cannot create a PoolableConnectionFactory`error, try setting `jdbc_params` to `enabledTLSProtocols=TLSv1.2`&#x20;
+If you see a `Cannot create a PoolableConnectionFactory`error, try setting `jdbc_params`
+to `enabledTLSProtocols=TLSv1.2`&#x20;
 :::
-
 
 ### Postgres
 
 <pre snippet="api-reference/source#postgres_source"></pre>
 
 :::warning
-If you see a `Cannot create a PoolableConnectionFactory`error, try setting **`jdbc_params` ** to **** `enabledTLSProtocols=TLSv1.2`&#x20;
+If you see a `Cannot create a PoolableConnectionFactory`error, try setting **`jdbc_params` **
+to **** `enabledTLSProtocols=TLSv1.2`&#x20;
 :::
-
 
 ### S3
 
 The following fields need to be defined on the source:
 
 1. **`name`** - A name to identify the source. The name should be unique across all sources.
-2. **`aws_access_key_id`** - In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper permissions. If accessing publicly available data, this field is not required.
-3. **`aws_secret_access_key`** - In order to access private S3 Buckets, this connector requires credentials with the proper permissions. If accessing publicly available data, this field is not required.
+2. **`aws_access_key_id`** (optional) - AWS Access Key ID. This field is not required if role-based access is used or if
+   the bucket is public.
+3. **`aws_secret_access_key`** (optional) - AWS Secret Access Key. This field is not required if role-based access is
+   used or if the bucket is public.
 
-And the following fields need to be defined on the bucket:
+:::info
+Fennel creates a special role with name prefixed by `FennelDataAccessRole-` in your AWS account for role-based access.
+:::
+
+The following fields need to be defined on the bucket:
 
 1. **`bucket`** - Name of the S3 bucket where the file(s) exist.
-2. **`prefix`** (optional) - By providing a path-like prefix (e.g., `myFolder/thisTable/`) under which all the relevant files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many folders/files&#x20;
-3. **`format`** (optional) - The format of the files you'd like to replicate. You can choose between CSV (default), Avro, Hudi and Parquet.&#x20;
-4. **`delimiter`** (optional) - the character delimiting individual cells in the CSV data. The default value is `","` and if overridden, this can only be a 1-character string. For example, to use tab-delimited data enter `"\t"`.
+2. **`prefix`** (optional) - By providing a path-like prefix (e.g., `myFolder/thisTable/`) under which all the relevant
+   files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many
+   folders/files&#x20;
+3. **`format`** (optional) - The format of the files you'd like to replicate. You can choose between CSV (default),
+   Avro, Hudi and Parquet.&#x20;
+4. **`delimiter`** (optional) - the character delimiting individual cells in the CSV data. The default value is `","`
+   and if overridden, this can only be a 1-character string. For example, to use tab-delimited data enter `"\t"`.
 
 <pre snippet="api-reference/source#s3_source"></pre>
 
 
-Fennel uses  `file_last_modified` property exported by S3 to track what data has been seen so far and hence a cursor field doesn't need to be specified.
-
-
+Fennel uses  `file_last_modified` property exported by S3 to track what data has been seen so far and hence a cursor
+field doesn't need to be specified.
 
 ### BigQuery
 
@@ -82,65 +92,86 @@ The following fields need to be specified:
 1. **`name`** - A name to identify the source. The name should be unique across all sources.
 2. **`project_id`** - The project ID of the Google Cloud project containing the BigQuery dataset.
 3. **`dataset_id`** - The ID of the BigQuery dataset containing the table(s) to replicate.
-4. **`credentials_json`** - The JSON string containing the credentials for the Service Account to use to access BigQuery. See below for instructions on how to obtain this.
-
+4. **`credentials_json`** - The JSON string containing the credentials for the Service Account to use to access
+   BigQuery. See below for instructions on how to obtain this.
 
 <details>
 
 <summary>How to obtain credentials? </summary>
 
-Interfacing with BigQuery requires credentials for a [Service Account](https://cloud.google.com/iam/docs/service-accounts) with the "BigQuery User" and "BigQuery Data Editor" roles, which grants permissions to run BigQuery jobs, write to BigQuery Datasets, and read table metadata. It is highly recommended that this Service Account is exclusive to Fennel for ease of permissions and auditing. However, you can also use a pre-existing Service Account if you already have one with the correct permissions.
+Interfacing with BigQuery requires credentials for
+a [Service Account](https://cloud.google.com/iam/docs/service-accounts) with the "BigQuery User" and "BigQuery Data
+Editor" roles, which grants permissions to run BigQuery jobs, write to BigQuery Datasets, and read table metadata. It is
+highly recommended that this Service Account is exclusive to Fennel for ease of permissions and auditing. However, you
+can also use a pre-existing Service Account if you already have one with the correct permissions.
 
-The easiest way to create a Service Account is to follow GCP's guide for [Creating a Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts). Once you've created the Service Account, make sure to keep its ID handy, as you will need to reference it when granting roles. Service Account IDs typically take the form `<account-name>@<project-name>.iam.gserviceaccount.com`
+The easiest way to create a Service Account is to follow GCP's guide
+for [Creating a Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts). Once you've
+created the Service Account, make sure to keep its ID handy, as you will need to reference it when granting roles.
+Service Account IDs typically take the form `<account-name>@<project-name>.iam.gserviceaccount.com`
 
-Then, add the service account as a Member of your Google Cloud Project with the "BigQuery User" role. To do this, follow the instructions for [Granting Access](https://cloud.google.com/iam/docs/granting-changing-revoking-access#granting-console) in the Google documentation. The email address of the member you are adding is the same as the Service Account ID you just created.
+Then, add the service account as a Member of your Google Cloud Project with the "BigQuery User" role. To do this, follow
+the instructions
+for [Granting Access](https://cloud.google.com/iam/docs/granting-changing-revoking-access#granting-console) in the
+Google documentation. The email address of the member you are adding is the same as the Service Account ID you just
+created.
 
 At this point, you should have a service account with the "BigQuery User" project-level permission.
 
-For Service Account Key JSON, enter the Google Cloud [Service Account Key in JSON format](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+For Service Account Key JSON, enter the Google
+Cloud [Service Account Key in JSON format](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
 
 </details>
-
 
 ### Snowflake
 
 The following fields need to be defined:
 
 1. **`name`** - A name to identify the source. The name should be unique across all sources.
-2. **`host`** - The host domain of the Snowflake instance (must include the account, region and cloud environment, and end with snowflakecomputing.com). Example: `accountname.us-east-2.aws.snowflakecomputing.com`.
+2. **`host`** - The host domain of the Snowflake instance (must include the account, region and cloud environment, and
+   end with snowflakecomputing.com). Example: `accountname.us-east-2.aws.snowflakecomputing.com`.
 3. **`role`** - The role that Fennel should use to access Snowflake.
 4. **`warehouse`** - The warehouse that Fennel should use to access Snowflake
 5. **`db_name`** - The database where the required data resides.
-6. **`schema`** - The default schema used as the target schema for all statements issued from the connection that do not explicitly specify a schema name.
-7. **`username`**  - The username that should be used to access Snowflake. Please note that the username should have the required permissions to assume the role provided.
+6. **`schema`** - The default schema used as the target schema for all statements issued from the connection that do not
+   explicitly specify a schema name.
+7. **`username`**  - The username that should be used to access Snowflake. Please note that the username should have the
+   required permissions to assume the role provided.
 8. **`password`** - The password associated with the username.
 
 <pre snippet="api-reference/source#snowflake_source"></pre>
 
 
 :::info
-Currently, Fennel only supports OAuth 1 (username and password) authentication. We are happy to prioritize support for OAuth 2.0 if needed - if so, please talk to us!
+Currently, Fennel only supports OAuth 1 (username and password) authentication. We are happy to prioritize support for
+OAuth 2.0 if needed - if so, please talk to us!
 :::
 
 ### HUDI
 
-The HUDI source is very similar to the S3 source, since HUDI is built on top of S3. The only additional field that needs to be specified is the `format` field, which should be set to "hudi". 
+The HUDI source is very similar to the S3 source, since HUDI is built on top of S3. The only additional field that needs
+to be specified is the `format` field, which should be set to "hudi".
 
 The following fields need to be defined:
 
 1. **`name`** - A name to identify the source. The name should be unique across all sources.
-2. **`aws_access_key_id`** - In order to access private Buckets stored on AWS S3, this connector requires credentials with the proper permissions. If accessing publicly available data, this field is not required.
-3. **`aws_secret_access_key`**- In order to access private S3 Buckets, this connector requires credentials with the proper permissions. If accessing publicly available data, this field is not required.
+2. **`aws_access_key_id`** - In order to access private Buckets stored on AWS S3, this connector requires credentials
+   with the proper permissions. If accessing publicly available data, this field is not required.
+3. **`aws_secret_access_key`**- In order to access private S3 Buckets, this connector requires credentials with the
+   proper permissions. If accessing publicly available data, this field is not required.
 
 And the following fields need to be defined on the bucket:
 
 1. **`bucket`** - Name of the S3 bucket where the file(s) exist.
-2. **`prefix`** (optional) - By providing a path-like prefix (e.g., `myFolder/thisTable/`) under which all the relevant files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many folders/files&#x20;
-3. **`format`** - Should be set to "hudi". 
+2. **`prefix`** (optional) - By providing a path-like prefix (e.g., `myFolder/thisTable/`) under which all the relevant
+   files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many
+   folders/files&#x20;
+3. **`format`** - Should be set to "hudi".
 
 <pre snippet="api-reference/source#s3_hudi_source"></pre>
 
 
-Fennel uses  `file_last_modified` property exported by S3 to track what data has been seen so far and hence a cursor field doesn't need to be specified.
+Fennel uses  `file_last_modified` property exported by S3 to track what data has been seen so far and hence a cursor
+field doesn't need to be specified.
 
 

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## [0.16.11] - 2023-07-20
+- Support role-based access to s3 data
+
 ## [0.16.10] - 2023-07-18
-- Bug fixes for the client. 
+- Bug fixes for the client.
 
 ## [0.16.6] - 2023-07-08
 - Support count unique for aggregations

--- a/fennel/lib/to_proto/to_proto.py
+++ b/fennel/lib/to_proto/to_proto.py
@@ -560,13 +560,15 @@ def _s3_conn_to_source_proto(
 
 
 def _s3_to_ext_db_proto(
-    name: str, aws_access_key_id: str, aws_secret_access_key: str
+    name: str,
+    aws_access_key_id: Optional[str],
+    aws_secret_access_key: Optional[str],
 ) -> connector_proto.ExtDatabase:
     return connector_proto.ExtDatabase(
         name=name,
         s3=connector_proto.S3(
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
+            aws_access_key_id=aws_access_key_id or "",
+            aws_secret_access_key=aws_secret_access_key or "",
         ),
     )
 

--- a/fennel/sources/sources.py
+++ b/fennel/sources/sources.py
@@ -139,8 +139,8 @@ class SQLSource(DataSource):
 
 
 class S3(DataSource):
-    aws_access_key_id: str
-    aws_secret_access_key: str
+    aws_access_key_id: Optional[str]
+    aws_secret_access_key: Optional[str]
 
     def _validate(self) -> List[Exception]:
         return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.16.10"
+version = "0.16.11"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
The system will automatically fallback to using role-based access for s3 sources if access key and secret access key are not specified.