### PR TITLE
DEV-1699 unit test for df -> columnar dict utility function

### DIFF
--- a/docs/examples/datasets/pipelines.py
+++ b/docs/examples/datasets/pipelines.py
@@ -66,7 +66,7 @@ class UserTransactionsAbroad:
             [
                 Count(window=Window("forever"), into_field="count"),
                 Sum(of="amount", window=Window("1d"), into_field="amount_1d"),
-                Sum(of="amount", window=Window("1d"), into_field="amount_1w"),
+                Sum(of="amount", window=Window("1w"), into_field="amount_1w"),
                 LastK(
                     of="merchant_id",
                     window=Window("1d"),

--- a/docs/pages/concepts/pipeline.md
+++ b/docs/pages/concepts/pipeline.md
@@ -51,7 +51,7 @@ ideas.
 
 Fennel pipelines are built out of a few general purpose operators like `filter`,
 `transform`, `join` etc which can be composed together to write any pipeline.
-You can read about all the operators [here](/concepts/pipeline#operators). Further,
+You can read about all the operators [here](/api-reference/operators). Further,
 a few operators (e.g. `transform`, `filter`) take free-form Python using which
 arbitrary computation can be done (including making calls into external services
 if needed). For all such operators, input/outputs variables are Pandas DataFrames

--- a/fennel/test_utils.py
+++ b/fennel/test_utils.py
@@ -1,5 +1,7 @@
 from fennel.utils import fhash, to_columnar_json
 
+import pandas as pd
+
 
 def test_fhash_Callable():
     def f(x: int, y: int) -> int:
@@ -35,4 +37,26 @@ def test_fhash_Callable():
 
 
 def test_to_columnar_json():
-    raise NotImplementedError("TODO zaki do this test")
+    col1 = pd.Series([True, False, True, False, True], name="isEven")
+    df1 = pd.DataFrame(col1)
+    dict1 = to_columnar_json(df1)
+    assert dict1["isEven"] == [True, False, True, False, True]
+    assert all(pd.DataFrame(dict1) == df1)
+
+    col2 = pd.Series([0, 10, 20, 30, 40])
+    col3 = pd.Series(["foo", "bar", "baz", "panda", "fennel"], name="names")
+    col4 = pd.Series([3.14, 2.71828, 9.81, 1.618, 0])
+    df2 = pd.DataFrame([col1, col2, col3, col4]).T
+    dict2 = to_columnar_json(df2)
+    expected = {
+        "isEven": [True, False, True, False, True],
+        "Unnamed 0": [0, 10, 20, 30, 40],
+        "names": ["foo", "bar", "baz", "panda", "fennel"],
+        "Unnamed 1": [3.14, 2.71828, 9.81, 1.618, 0],
+    }
+    expected_str = '{"isEven": [true, false, true, false, true], "Unnamed 0": [0, 10, 20, 30, 40], "names": ["foo", "bar", "baz", "panda", "fennel"], "Unnamed 1": [3.14, 2.71828, 9.81, 1.618, 0.0]}'
+    assert dict2 == expected
+    assert all(pd.DataFrame(dict2) == df2)
+
+    dict_as_str = to_columnar_json(df2, as_str=True)
+    assert dict_as_str == expected_str

--- a/fennel/test_utils.py
+++ b/fennel/test_utils.py
@@ -1,4 +1,4 @@
-from fennel.utils import fhash
+from fennel.utils import fhash, to_columnar_json
 
 
 def test_fhash_Callable():
@@ -32,3 +32,7 @@ def test_fhash_Callable():
         return x + y
 
     assert fhash(f) == hash_code
+
+
+def test_to_columnar_json():
+    raise NotImplementedError("TODO zaki do this test")

--- a/fennel/test_utils.py
+++ b/fennel/test_utils.py
@@ -1,5 +1,8 @@
 from fennel.utils import fhash, to_columnar_json
+from datetime import datetime, timezone
+from math import nan
 
+import json
 import pandas as pd
 
 
@@ -37,12 +40,14 @@ def test_fhash_Callable():
 
 
 def test_to_columnar_json():
+    # single col
     col1 = pd.Series([True, False, True, False, True], name="isEven")
     df1 = pd.DataFrame(col1)
     dict1 = to_columnar_json(df1)
     assert dict1["isEven"] == [True, False, True, False, True]
     assert all(pd.DataFrame(dict1) == df1)
 
+    # multiple cols
     col2 = pd.Series([0, 10, 20, 30, 40])
     col3 = pd.Series(["foo", "bar", "baz", "panda", "fennel"], name="names")
     col4 = pd.Series([3.14, 2.71828, 9.81, 1.618, 0])
@@ -60,3 +65,29 @@ def test_to_columnar_json():
 
     dict_as_str = to_columnar_json(df2, as_str=True)
     assert dict_as_str == expected_str
+
+    # contains nulls and timestamps, handle in json way
+    now = datetime.now(timezone.utc)
+    df3 = pd.DataFrame(
+        [
+            [1, "abc", None, 3.14, now],
+            [nan, "def", False, 2.71828, now],
+        ]
+    ).rename(columns={0: "num", 1: "word", 2: "bool", 3: "math", 4: "time"})
+    now_ms = int(now.timestamp() * 1000)
+    expected = {
+        "num": [1.0, None],
+        "word": ["abc", "def"],
+        "bool": [None, False],
+        "math": [3.14, 2.71828],
+        "time": [now_ms, now_ms],
+    }
+    # str encodes Nones and nans as 'null'
+    expected_str = (
+        "{"
+        + f'"num": [1.0, null], "word": ["abc", "def"], "bool": [null, false], "math": [3.14, 2.71828], "time": [{now_ms}, {now_ms}]'
+        + "}"
+    )
+    assert to_columnar_json(df3) == expected
+    assert to_columnar_json(df3, as_str=True) == expected_str
+    assert json.loads(to_columnar_json(df3, as_str=True)) == expected


### PR DESCRIPTION
Unit test follow up to #259

`pd.to_json()` doesn't have a builtin way of the exact format we wanted: `dict[col] -> [values]`
`pd.to_dict` has this option, but `to_dict` handles `NaNs`, `Nones`, and `timestamps` differently from `to_json`.
Therefore we provide a custom function for converting dicts to columnar json. This PR provides unit tests for that function. 

I also added a couple typo fixes in the docs pages that I found as I was reading through the docs