### PR TITLE
client: Report error response only once in sync and extract features call

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.18.21] - 2023-11-18
+- Fix error response being logged twice in the client for sync and extract_features.
+
 ## [0.18.15] - 2023-11-12
 - Allow owner to be specified at the file level itself. 
 

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -101,7 +101,6 @@ class Client:
             False,
             300,
         )
-        check_response(response)
         if response.headers.get("content-type") == "application/json":
             res_json = response.json()
             if "diffs" in res_json:
@@ -395,7 +394,6 @@ class Client:
             req["sampling_rate"] = sampling_rate
 
         response = self._post_json("{}/extract_features".format(V1_API), req)
-        check_response(response)
         df = pd.DataFrame(response.json())
         for col in df.columns:
             if df[col].dtype == "object":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.18.20"
+version = "0.18.21"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
check_response is already called in `_get` and `_post` methods which are used by all the REST calls from the client

For a single extract features call, I see two error statements - 

```
Server returned: 500, Internal Server Error, error: FeatureSet not found: UserPageViewFeaturesFSDS
Server returned: 500, Internal Server Error, error: FeatureSet not found: UserPageViewFeaturesFSDS
```

Similarly see such errors for sync call in case sync fails completely