### PR TITLE
Fix assign logging dtype checks

### DIFF
--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -112,7 +112,7 @@ class Client:
         self,
         webhook: str,
         endpoint: str,
-        dataframe: pd.DataFrame,
+        df: pd.DataFrame,
         batch_size: int = 1000,
     ):
         """
@@ -127,7 +127,7 @@ class Client:
         Returns:
         Dict: response from the server
         """
-        num_rows = dataframe.shape[0]
+        num_rows = df.shape[0]
         if num_rows == 0:
             print(f"No rows to log to webhook {webhook}:{endpoint}")
             return
@@ -135,7 +135,7 @@ class Client:
         for i in range(math.ceil(num_rows / batch_size)):
             start = i * batch_size
             end = min((i + 1) * batch_size, num_rows)
-            mini_df = dataframe[start:end]
+            mini_df = df[start:end]
             payload = to_columnar_json(mini_df)
             req = {
                 "webhook": webhook,

--- a/fennel/datasets/test_invalid_dataset.py
+++ b/fennel/datasets/test_invalid_dataset.py
@@ -882,34 +882,54 @@ webhook = Webhook(name="fennel_webhook")
 __owner__ = "eng@fennel.ai"
 
 
-def test_invalid_assign_schema():
-    with pytest.raises(Exception) as e:
+@mock
+def test_invalid_assign_schema(client):
+    @source(webhook.endpoint("mysql_relayrides.location"), tier="local")
+    @dataset
+    class LocationDS:
+        id: int = field(key=True)
+        latitude: float
+        longitude: float
+        created: datetime
 
-        @source(webhook.endpoint("mysql_relayrides.location"), tier="local")
-        @dataset
-        class LocationDS:
-            id: int = field(key=True)
-            latitude: float
-            longitude: float
-            created: datetime
+    @dataset
+    class LocationDS2:
+        latitude_int: int = field(key=True)
+        longitude_int: int = field(key=True)
+        id: int
+        created: datetime
 
-        @dataset
-        class LocationDS2:
-            latitude_int: int = field(key=True)
-            longitude_int: int = field(key=True)
-            id: int
-            created: datetime
+        @pipeline(version=1)
+        @inputs(LocationDS)
+        def location_ds(cls, location: Dataset):
+            ds = location.assign(
+                "latitude_int", int, lambda df: df["latitude"] * 1000
+            )
+            ds = ds.assign(
+                "longitude_int", int, lambda df: df["longitude"] * 1000
+            )
+            ds = ds.drop(["latitude", "longitude"])
+            return ds.groupby(["latitude_int", "longitude_int"]).first()
 
-            @pipeline(version=1)
-            @inputs(LocationDS)
-            def location_ds(cls, location: Dataset):
-                ds = location.assign(
-                    "latitude_int", int, lambda df: int(df["latitude"] * 1000)
-                )
-                ds = ds.assign(
-                    "longitude_int", int, lambda df: int(df["longitude"] * 1000)
-                )
-                ds = ds.drop(["latitude", "longitude"])
-                return ds.groupby(["latitude_int", "longitude_int"]).first()
+    client.sync(
+        datasets=[LocationDS, LocationDS2],
+    )
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "latitude": [1.12312, 2.3423423, 2.24343],
+            "longitude": [1.12312, 2.3423423, 2.24343],
+            "created": [
+                datetime.fromtimestamp(1672858163),
+                datetime.fromtimestamp(1672858163),
+                datetime.fromtimestamp(1672858163),
+            ],
+        }
+    )
+    res = client.log("fennel_webhook", "mysql_relayrides.location", df)
 
-    assert str(e.value) == "sdf"
+    assert res.status_code == 400, res.json()
+    assert (
+        res.json()["error"]
+        == "Error while executing pipeline location_ds in dataset LocationDS: Error in assign node for column `latitude_int` for pipeline `LocationDS2.location_ds`, cannot safely cast non-equivalent float64 to int64"
+    )

--- a/fennel/test_lib/mock_client.py
+++ b/fennel/test_lib/mock_client.py
@@ -657,9 +657,16 @@ class MockClient(Client):
         self._merge_df(df, dataset_name)
         for pipeline in self.listeners[dataset_name]:
             executor = Executor(self.data)
-            ret = executor.execute(
-                pipeline, self.datasets[pipeline._dataset_name]
-            )
+            try:
+                ret = executor.execute(
+                    pipeline, self.datasets[pipeline._dataset_name]
+                )
+            except Exception as e:
+                return FakeResponse(
+                    400,
+                    f"Error while executing pipeline {pipeline.name} "
+                    f"in dataset {dataset_name}: {str(e)}",
+                )
             if ret is None:
                 continue
             if ret.is_aggregate:

--- a/fennel/test_lib/test_utils.py
+++ b/fennel/test_lib/test_utils.py
@@ -86,7 +86,15 @@ def cast_col_to_dtype(series: pd.Series, dtype) -> pd.Series:
     if not dtype.HasField("optional_type"):
         if series.isnull().any():
             raise ValueError("Null values found in non-optional field.")
+
     if dtype.HasField("int_type"):
+        if series.dtype == pd.Float64Dtype():
+            # Cast to float64 numpy. We need to do this, because pandas has a wierd bug,
+            # where series of type float64 will throw an error if the floats are not ints ( expected ).
+            # For example, series([1.2, 2.4, 3.3]) will throw an error.
+            # BUT series of type pd.Float64Dtype() will not throw an error, but get rounded off.
+            # So we cast to float64 numpy and then cast to pd.Int64Dtype()
+            series = series.astype(np.float64)
         return pd.to_numeric(series).astype(pd.Int64Dtype())
     elif dtype.HasField("double_type"):
         return pd.to_numeric(series).astype(pd.Float64Dtype())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.18.24"
+version = "0.18.25"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
1. Cast issue - See comment in fennel/test_lib/test_utils.py
 2. log API in mock client takes df as param and prod client takes dataframe, making it df. This is a breaking change, but I dont think anyone uses the python log api in prod ?