### PR TITLE
Update docs for extract historical request

### DIFF
--- a/docs/examples/api-reference/client.py
+++ b/docs/examples/api-reference/client.py
@@ -128,3 +128,32 @@ class TestExtractorDAGResolution(unittest.TestCase):
             timestamp_column="timestamp",
         )
         # /docsnip
+
+        with self.assertRaises(NotImplementedError) as e:
+            # docsnip extract_historical_features_s3
+            from fennel.sources import S3
+
+            s3 = S3(
+                name="extract_hist_input",
+                aws_access_key_id="<ACCESS KEY HERE>",
+                aws_secret_access_key="<SECRET KEY HERE>",
+            )
+            s3_input_connection = s3.bucket(
+                "bucket", prefix="data/user_features"
+            )
+            s3_output_connection = s3.bucket("bucket", prefix="output")
+
+            response = client.extract_historical_features(
+                output_feature_list=[
+                    UserFeatures,
+                ],
+                input_feature_list=[UserFeatures.userid],
+                format="csv",
+                timestamp_column="timestamp",
+                input_s3=s3_input_connection,
+                output_s3=s3_output_connection,
+            )
+            # /docsnip
+        assert "Only pandas format is supported in MockClient" in str(
+            e.exception
+        )

--- a/docs/pages/api-reference/client.md
+++ b/docs/pages/api-reference/client.md
@@ -113,7 +113,7 @@ A completion rate of 1.0 and a failure rate of 0.0 indicates that all processing
 
 **Example**
 
-Here is an exmaple with `format="pandas"` and the default output bucket
+Here is an example with `format="pandas"` and the default output bucket
 
 <pre snippet="api-reference/client#extract_historical_features_api"></pre>
 

--- a/docs/pages/api-reference/client.md
+++ b/docs/pages/api-reference/client.md
@@ -88,14 +88,14 @@ This api is an asynchronous api that returns a request id and the path to the ou
 * `timestamp_column: str` - The name of the column containing the timestamps.
 * `format: str` - The format of the input data. Can be either "pandas", "csv", "json" or "parquet". Default is "pandas".
 * `input_dataframe: Optional[pd.DataFrame]` - Dataframe containing the input features. Only relevant when format is "pandas".
-* `output_bucket: Optional[str]` - The name of the S3 bucket where the output data should be stored.
-* `output_prefix: Optional[str]` - The prefix of the S3 key where the output data should be stored.
+* `output_s3: Optional[sources.S3Connector]` - Specifies the S3 bucket, prefix, and optional credentials for where the output data should be stored.
 
 The following parameters are only relevant when format is "csv", "json" or "parquet".
 
-* `input_bucket: Optional[str]` - The name of the S3 bucket containing the input data. 
-* `input_prefix: Optional[str]` - The prefix of the S3 key containing the input data. 
+* `input_s3: Optional[sources.S3Connector]` - Specifies the S3 bucket, prefix, and optional credentials for the input data
 * ` feature_to_column_map (Optional[Dict[Feature, str]])`: A dictionary mapping features to column names. 
+
+The `S3Connector` paramters are provided via the `S3.bucket()` function from the `sources` module. See [Sources](/api-reference/sources#s3)
 
 **Returns:**
 

--- a/docs/pages/api-reference/client.md
+++ b/docs/pages/api-reference/client.md
@@ -95,7 +95,7 @@ The following parameters are only relevant when format is "csv", "json" or "parq
 * `input_s3: Optional[sources.S3Connector]` - Specifies the S3 bucket, prefix, and optional credentials for the input data
 * ` feature_to_column_map (Optional[Dict[Feature, str]])`: A dictionary mapping features to column names. 
 
-The `S3Connector` paramters are provided via the `S3.bucket()` function from the `sources` module. See [Sources](/api-reference/sources#s3)
+The `S3Connector` parameters are provided via the `S3.bucket()` function from the `sources` module. See [Sources](/api-reference/sources#s3)
 
 **Returns:**
 

--- a/docs/pages/api-reference/client.md
+++ b/docs/pages/api-reference/client.md
@@ -113,7 +113,13 @@ A completion rate of 1.0 and a failure rate of 0.0 indicates that all processing
 
 **Example**
 
+Here is an exmaple with `format="pandas"` and the default output bucket
+
 <pre snippet="api-reference/client#extract_historical_features_api"></pre>
+
+Here is an example specifying input and output S3 buckets
+
+<pre snippet="api-reference/client#extract_historical_features_s3"></pre>
 
 ****
 


### PR DESCRIPTION
local docs rendering. Links to the S3 section on the sources page. 


<img width="1102" alt="Screenshot 2023-11-29 at 10 43 07 AM" src="https://github.com/fennel-ai/client/assets/8029573/4c4a3c1c-2de1-452d-9dc6-8212b2f82da6">

With example:

<img width="1052" alt="image" src="https://github.com/fennel-ai/client/assets/8029573/5b64217f-4fd7-4a31-8e4c-aee6085c3ef1">

