### PR TITLE
sources: add pre_proc argument on sources.

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.19.1] - 2023-12-05
+- Add support for `pre_proc` on `@sources` to specify default values for columns which may not exist in the data sources.
+
 ## [0.19.0] - 2023-11-28
 - Allow for AWS access key credentials for extract_historical_features buckets
 

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -67,7 +67,7 @@ from fennel.lib.schema import (
     FENNEL_STRUCT_DEPENDENCIES_SRC_CODE,
 )
 
-from fennel.sources.sources import DataConnector, source
+from fennel.sources.sources import DataConnector, source, PreProcValue
 from fennel.utils import (
     fhash,
     parse_annotation_comments,
@@ -1191,6 +1191,7 @@ class Dataset(_Node[T]):
         every: Optional[Duration] = None,
         starting_from: Optional[datetime.datetime] = None,
         lateness: Optional[Duration] = None,
+        pre_proc: Optional[Dict[str, PreProcValue]] = None,
         tiers: Optional[Union[str, List[str]]] = None,
     ):
         logger = logging.getLogger(__name__)
@@ -1205,7 +1206,9 @@ class Dataset(_Node[T]):
         ds_copy = copy.deepcopy(self)
         if hasattr(ds_copy, sources.SOURCE_FIELD):
             delattr(ds_copy, sources.SOURCE_FIELD)
-        src_fn = source(conn, every, starting_from, lateness, None, tiers)
+        src_fn = source(
+            conn, every, starting_from, lateness, None, tiers, pre_proc
+        )
         return src_fn(ds_copy)
 
     def dsschema(self):

--- a/fennel/gen/auth_pb2.py
+++ b/fennel/gen/auth_pb2.py
@@ -19,7 +19,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'auth_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_ORGPERMISSION']._serialized_start=34
   _globals['_ORGPERMISSION']._serialized_end=218

--- a/fennel/gen/connector_pb2.py
+++ b/fennel/gen/connector_pb2.py
@@ -16,70 +16,76 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 from google.protobuf import wrappers_pb2 as google_dot_protobuf_dot_wrappers__pb2
 import fennel.gen.kinesis_pb2 as kinesis__pb2
 import fennel.gen.schema_registry_pb2 as schema__registry__pb2
+import fennel.gen.schema_pb2 as schema__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0f\x63onnector.proto\x12\x16\x66\x65nnel.proto.connector\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\rkinesis.proto\x1a\x15schema_registry.proto\"\xf4\x03\n\x0b\x45xtDatabase\x12\x0c\n\x04name\x18\x01 \x01(\t\x12.\n\x05mysql\x18\x02 \x01(\x0b\x32\x1d.fennel.proto.connector.MySQLH\x00\x12\x34\n\x08postgres\x18\x03 \x01(\x0b\x32 .fennel.proto.connector.PostgresH\x00\x12\x36\n\treference\x18\x04 \x01(\x0b\x32!.fennel.proto.connector.ReferenceH\x00\x12(\n\x02s3\x18\x05 \x01(\x0b\x32\x1a.fennel.proto.connector.S3H\x00\x12\x34\n\x08\x62igquery\x18\x06 \x01(\x0b\x32 .fennel.proto.connector.BigqueryH\x00\x12\x36\n\tsnowflake\x18\x07 \x01(\x0b\x32!.fennel.proto.connector.SnowflakeH\x00\x12.\n\x05kafka\x18\x08 \x01(\x0b\x32\x1d.fennel.proto.connector.KafkaH\x00\x12\x32\n\x07webhook\x18\t \x01(\x0b\x32\x1f.fennel.proto.connector.WebhookH\x00\x12\x32\n\x07kinesis\x18\n \x01(\x0b\x32\x1f.fennel.proto.connector.KinesisH\x00\x42\t\n\x07variant\"\x80\x01\n\x0bKafkaFormat\x12\x32\n\x04json\x18\x01 \x01(\x0b\x32\".fennel.proto.connector.JsonFormatH\x00\x12\x32\n\x04\x61vro\x18\x02 \x01(\x0b\x32\".fennel.proto.connector.AvroFormatH\x00\x42\t\n\x07variant\"\x0c\n\nJsonFormat\"S\n\nAvroFormat\x12\x45\n\x0fschema_registry\x18\x01 \x01(\x0b\x32,.fennel.proto.schema_registry.SchemaRegistry\"\xb8\x01\n\tReference\x12;\n\x06\x64\x62type\x18\x01 \x01(\x0e\x32+.fennel.proto.connector.Reference.ExtDBType\"n\n\tExtDBType\x12\t\n\x05MYSQL\x10\x00\x12\x0c\n\x08POSTGRES\x10\x01\x12\x06\n\x02S3\x10\x02\x12\t\n\x05KAFKA\x10\x03\x12\x0c\n\x08\x42IGQUERY\x10\x04\x12\r\n\tSNOWFLAKE\x10\x05\x12\x0b\n\x07WEBHOOK\x10\x06\x12\x0b\n\x07KINESIS\x10\x07\"\x17\n\x07Webhook\x12\x0c\n\x04name\x18\x01 \x01(\t\"j\n\x05MySQL\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\x02 \x01(\t\x12\x0c\n\x04user\x18\x03 \x01(\t\x12\x10\n\x08password\x18\x04 \x01(\t\x12\x0c\n\x04port\x18\x05 \x01(\r\x12\x13\n\x0bjdbc_params\x18\x06 \x01(\t\"m\n\x08Postgres\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\x02 \x01(\t\x12\x0c\n\x04user\x18\x03 \x01(\t\x12\x10\n\x08password\x18\x04 \x01(\t\x12\x0c\n\x04port\x18\x05 \x01(\r\x12\x13\n\x0bjdbc_params\x18\x06 \x01(\t\">\n\x02S3\x12\x1d\n\x15\x61ws_secret_access_key\x18\x01 \x01(\t\x12\x19\n\x11\x61ws_access_key_id\x18\x02 \x01(\t\"I\n\x08\x42igquery\x12\x0f\n\x07\x64\x61taset\x18\x01 \x01(\t\x12\x18\n\x10\x63redentials_json\x18\x02 \x01(\t\x12\x12\n\nproject_id\x18\x03 \x01(\t\"\x94\x01\n\tSnowflake\x12\x0f\n\x07\x61\x63\x63ount\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x10\n\x08password\x18\x03 \x01(\t\x12\x0e\n\x06schema\x18\x04 \x01(\t\x12\x11\n\twarehouse\x18\x05 \x01(\t\x12\x0c\n\x04role\x18\x06 \x01(\t\x12\x13\n\x0bjdbc_params\x18\x07 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\t \x01(\t\"\x8c\x02\n\x05Kafka\x12\x19\n\x11\x62ootstrap_servers\x18\x01 \x01(\t\x12\x19\n\x11security_protocol\x18\x02 \x01(\t\x12\x16\n\x0esasl_mechanism\x18\x03 \x01(\t\x12\x1c\n\x10sasl_jaas_config\x18\x04 \x01(\tB\x02\x18\x01\x12\x1b\n\x13sasl_plain_username\x18\x05 \x01(\t\x12\x1b\n\x13sasl_plain_password\x18\x06 \x01(\t\x12\x14\n\x08group_id\x18\x07 \x01(\tB\x02\x18\x01\x12G\n#enable_ssl_certificate_verification\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\"\x1b\n\x07Kinesis\x12\x10\n\x08role_arn\x18\x01 \x01(\t\"\xfd\x03\n\x08\x45xtTable\x12\x39\n\x0bmysql_table\x18\x01 \x01(\x0b\x32\".fennel.proto.connector.MySQLTableH\x00\x12\x39\n\x08pg_table\x18\x02 \x01(\x0b\x32%.fennel.proto.connector.PostgresTableH\x00\x12\x33\n\x08s3_table\x18\x03 \x01(\x0b\x32\x1f.fennel.proto.connector.S3TableH\x00\x12\x39\n\x0bkafka_topic\x18\x04 \x01(\x0b\x32\".fennel.proto.connector.KafkaTopicH\x00\x12\x41\n\x0fsnowflake_table\x18\x05 \x01(\x0b\x32&.fennel.proto.connector.SnowflakeTableH\x00\x12?\n\x0e\x62igquery_table\x18\x06 \x01(\x0b\x32%.fennel.proto.connector.BigqueryTableH\x00\x12;\n\x08\x65ndpoint\x18\x07 \x01(\x0b\x32\'.fennel.proto.connector.WebhookEndpointH\x00\x12?\n\x0ekinesis_stream\x18\x08 \x01(\x0b\x32%.fennel.proto.connector.KinesisStreamH\x00\x42\t\n\x07variant\"Q\n\nMySQLTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"T\n\rPostgresTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"\x96\x01\n\x07S3Table\x12\x0e\n\x06\x62ucket\x18\x01 \x01(\t\x12\x13\n\x0bpath_prefix\x18\x02 \x01(\t\x12\x11\n\tdelimiter\x18\x04 \x01(\t\x12\x0e\n\x06\x66ormat\x18\x05 \x01(\t\x12/\n\x02\x64\x62\x18\x06 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\npre_sorted\x18\x07 \x01(\x08\"\x81\x01\n\nKafkaTopic\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\r\n\x05topic\x18\x02 \x01(\t\x12\x33\n\x06\x66ormat\x18\x03 \x01(\x0b\x32#.fennel.proto.connector.KafkaFormat\"T\n\rBigqueryTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"U\n\x0eSnowflakeTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"T\n\x0fWebhookEndpoint\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x10\n\x08\x65ndpoint\x18\x02 \x01(\t\"\xd3\x01\n\rKinesisStream\x12\x12\n\nstream_arn\x18\x01 \x01(\t\x12\x39\n\rinit_position\x18\x02 \x01(\x0e\x32\".fennel.proto.kinesis.InitPosition\x12\x32\n\x0einit_timestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06\x66ormat\x18\x04 \x01(\t\x12/\n\x02\x64\x62\x18\x05 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\"\xbf\x02\n\x06Source\x12/\n\x05table\x18\x01 \x01(\x0b\x32 .fennel.proto.connector.ExtTable\x12\x0f\n\x07\x64\x61taset\x18\x02 \x01(\t\x12(\n\x05\x65very\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x13\n\x06\x63ursor\x18\x04 \x01(\tH\x00\x88\x01\x01\x12+\n\x08lateness\x18\x05 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x17\n\x0ftimestamp_field\x18\x06 \x01(\t\x12\x30\n\x03\x63\x64\x63\x18\x07 \x01(\x0e\x32#.fennel.proto.connector.CDCStrategy\x12\x31\n\rstarting_from\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.TimestampB\t\n\x07_cursor\"H\n\x04Sink\x12/\n\x05table\x18\x01 \x01(\x0b\x32 .fennel.proto.connector.ExtTable\x12\x0f\n\x07\x64\x61taset\x18\x02 \x01(\t*K\n\x0b\x43\x44\x43Strategy\x12\n\n\x06\x41ppend\x10\x00\x12\n\n\x06Upsert\x10\x01\x12\x0c\n\x08\x44\x65\x62\x65zium\x10\x02\x12\n\n\x06Native\x10\x03\x12\n\n\x06\x44\x65lete\x10\x04\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0f\x63onnector.proto\x12\x16\x66\x65nnel.proto.connector\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\rkinesis.proto\x1a\x15schema_registry.proto\x1a\x0cschema.proto\"\xf4\x03\n\x0b\x45xtDatabase\x12\x0c\n\x04name\x18\x01 \x01(\t\x12.\n\x05mysql\x18\x02 \x01(\x0b\x32\x1d.fennel.proto.connector.MySQLH\x00\x12\x34\n\x08postgres\x18\x03 \x01(\x0b\x32 .fennel.proto.connector.PostgresH\x00\x12\x36\n\treference\x18\x04 \x01(\x0b\x32!.fennel.proto.connector.ReferenceH\x00\x12(\n\x02s3\x18\x05 \x01(\x0b\x32\x1a.fennel.proto.connector.S3H\x00\x12\x34\n\x08\x62igquery\x18\x06 \x01(\x0b\x32 .fennel.proto.connector.BigqueryH\x00\x12\x36\n\tsnowflake\x18\x07 \x01(\x0b\x32!.fennel.proto.connector.SnowflakeH\x00\x12.\n\x05kafka\x18\x08 \x01(\x0b\x32\x1d.fennel.proto.connector.KafkaH\x00\x12\x32\n\x07webhook\x18\t \x01(\x0b\x32\x1f.fennel.proto.connector.WebhookH\x00\x12\x32\n\x07kinesis\x18\n \x01(\x0b\x32\x1f.fennel.proto.connector.KinesisH\x00\x42\t\n\x07variant\"\x80\x01\n\x0bKafkaFormat\x12\x32\n\x04json\x18\x01 \x01(\x0b\x32\".fennel.proto.connector.JsonFormatH\x00\x12\x32\n\x04\x61vro\x18\x02 \x01(\x0b\x32\".fennel.proto.connector.AvroFormatH\x00\x42\t\n\x07variant\"\x0c\n\nJsonFormat\"S\n\nAvroFormat\x12\x45\n\x0fschema_registry\x18\x01 \x01(\x0b\x32,.fennel.proto.schema_registry.SchemaRegistry\"\xb8\x01\n\tReference\x12;\n\x06\x64\x62type\x18\x01 \x01(\x0e\x32+.fennel.proto.connector.Reference.ExtDBType\"n\n\tExtDBType\x12\t\n\x05MYSQL\x10\x00\x12\x0c\n\x08POSTGRES\x10\x01\x12\x06\n\x02S3\x10\x02\x12\t\n\x05KAFKA\x10\x03\x12\x0c\n\x08\x42IGQUERY\x10\x04\x12\r\n\tSNOWFLAKE\x10\x05\x12\x0b\n\x07WEBHOOK\x10\x06\x12\x0b\n\x07KINESIS\x10\x07\"\x17\n\x07Webhook\x12\x0c\n\x04name\x18\x01 \x01(\t\"j\n\x05MySQL\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\x02 \x01(\t\x12\x0c\n\x04user\x18\x03 \x01(\t\x12\x10\n\x08password\x18\x04 \x01(\t\x12\x0c\n\x04port\x18\x05 \x01(\r\x12\x13\n\x0bjdbc_params\x18\x06 \x01(\t\"m\n\x08Postgres\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\x02 \x01(\t\x12\x0c\n\x04user\x18\x03 \x01(\t\x12\x10\n\x08password\x18\x04 \x01(\t\x12\x0c\n\x04port\x18\x05 \x01(\r\x12\x13\n\x0bjdbc_params\x18\x06 \x01(\t\">\n\x02S3\x12\x1d\n\x15\x61ws_secret_access_key\x18\x01 \x01(\t\x12\x19\n\x11\x61ws_access_key_id\x18\x02 \x01(\t\"I\n\x08\x42igquery\x12\x0f\n\x07\x64\x61taset\x18\x01 \x01(\t\x12\x18\n\x10\x63redentials_json\x18\x02 \x01(\t\x12\x12\n\nproject_id\x18\x03 \x01(\t\"\x94\x01\n\tSnowflake\x12\x0f\n\x07\x61\x63\x63ount\x18\x01 \x01(\t\x12\x0c\n\x04user\x18\x02 \x01(\t\x12\x10\n\x08password\x18\x03 \x01(\t\x12\x0e\n\x06schema\x18\x04 \x01(\t\x12\x11\n\twarehouse\x18\x05 \x01(\t\x12\x0c\n\x04role\x18\x06 \x01(\t\x12\x13\n\x0bjdbc_params\x18\x07 \x01(\t\x12\x10\n\x08\x64\x61tabase\x18\t \x01(\t\"\x8c\x02\n\x05Kafka\x12\x19\n\x11\x62ootstrap_servers\x18\x01 \x01(\t\x12\x19\n\x11security_protocol\x18\x02 \x01(\t\x12\x16\n\x0esasl_mechanism\x18\x03 \x01(\t\x12\x1c\n\x10sasl_jaas_config\x18\x04 \x01(\tB\x02\x18\x01\x12\x1b\n\x13sasl_plain_username\x18\x05 \x01(\t\x12\x1b\n\x13sasl_plain_password\x18\x06 \x01(\t\x12\x14\n\x08group_id\x18\x07 \x01(\tB\x02\x18\x01\x12G\n#enable_ssl_certificate_verification\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.BoolValue\"\x1b\n\x07Kinesis\x12\x10\n\x08role_arn\x18\x01 \x01(\t\"\xfd\x03\n\x08\x45xtTable\x12\x39\n\x0bmysql_table\x18\x01 \x01(\x0b\x32\".fennel.proto.connector.MySQLTableH\x00\x12\x39\n\x08pg_table\x18\x02 \x01(\x0b\x32%.fennel.proto.connector.PostgresTableH\x00\x12\x33\n\x08s3_table\x18\x03 \x01(\x0b\x32\x1f.fennel.proto.connector.S3TableH\x00\x12\x39\n\x0bkafka_topic\x18\x04 \x01(\x0b\x32\".fennel.proto.connector.KafkaTopicH\x00\x12\x41\n\x0fsnowflake_table\x18\x05 \x01(\x0b\x32&.fennel.proto.connector.SnowflakeTableH\x00\x12?\n\x0e\x62igquery_table\x18\x06 \x01(\x0b\x32%.fennel.proto.connector.BigqueryTableH\x00\x12;\n\x08\x65ndpoint\x18\x07 \x01(\x0b\x32\'.fennel.proto.connector.WebhookEndpointH\x00\x12?\n\x0ekinesis_stream\x18\x08 \x01(\x0b\x32%.fennel.proto.connector.KinesisStreamH\x00\x42\t\n\x07variant\"Q\n\nMySQLTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"T\n\rPostgresTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"\x96\x01\n\x07S3Table\x12\x0e\n\x06\x62ucket\x18\x01 \x01(\t\x12\x13\n\x0bpath_prefix\x18\x02 \x01(\t\x12\x11\n\tdelimiter\x18\x04 \x01(\t\x12\x0e\n\x06\x66ormat\x18\x05 \x01(\t\x12/\n\x02\x64\x62\x18\x06 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\npre_sorted\x18\x07 \x01(\x08\"\x81\x01\n\nKafkaTopic\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\r\n\x05topic\x18\x02 \x01(\t\x12\x33\n\x06\x66ormat\x18\x03 \x01(\x0b\x32#.fennel.proto.connector.KafkaFormat\"T\n\rBigqueryTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"U\n\x0eSnowflakeTable\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x12\n\ntable_name\x18\x02 \x01(\t\"T\n\x0fWebhookEndpoint\x12/\n\x02\x64\x62\x18\x01 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\x12\x10\n\x08\x65ndpoint\x18\x02 \x01(\t\"\xd3\x01\n\rKinesisStream\x12\x12\n\nstream_arn\x18\x01 \x01(\t\x12\x39\n\rinit_position\x18\x02 \x01(\x0e\x32\".fennel.proto.kinesis.InitPosition\x12\x32\n\x0einit_timestamp\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0e\n\x06\x66ormat\x18\x04 \x01(\t\x12/\n\x02\x64\x62\x18\x05 \x01(\x0b\x32#.fennel.proto.connector.ExtDatabase\"U\n\x0cPreProcValue\x12\r\n\x03ref\x18\x01 \x01(\tH\x00\x12+\n\x05value\x18\x02 \x01(\x0b\x32\x1a.fennel.proto.schema.ValueH\x00\x42\t\n\x07variant\"\xd4\x03\n\x06Source\x12/\n\x05table\x18\x01 \x01(\x0b\x32 .fennel.proto.connector.ExtTable\x12\x0f\n\x07\x64\x61taset\x18\x02 \x01(\t\x12(\n\x05\x65very\x18\x03 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x13\n\x06\x63ursor\x18\x04 \x01(\tH\x00\x88\x01\x01\x12+\n\x08lateness\x18\x05 \x01(\x0b\x32\x19.google.protobuf.Duration\x12\x17\n\x0ftimestamp_field\x18\x06 \x01(\t\x12\x30\n\x03\x63\x64\x63\x18\x07 \x01(\x0e\x32#.fennel.proto.connector.CDCStrategy\x12\x31\n\rstarting_from\x18\x08 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12=\n\x08pre_proc\x18\t \x03(\x0b\x32+.fennel.proto.connector.Source.PreProcEntry\x1aT\n\x0cPreProcEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32$.fennel.proto.connector.PreProcValue:\x02\x38\x01\x42\t\n\x07_cursor\"H\n\x04Sink\x12/\n\x05table\x18\x01 \x01(\x0b\x32 .fennel.proto.connector.ExtTable\x12\x0f\n\x07\x64\x61taset\x18\x02 \x01(\t*K\n\x0b\x43\x44\x43Strategy\x12\n\n\x06\x41ppend\x10\x00\x12\n\n\x06Upsert\x10\x01\x12\x0c\n\x08\x44\x65\x62\x65zium\x10\x02\x12\n\n\x06Native\x10\x03\x12\n\n\x06\x44\x65lete\x10\x04\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'connector_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
-  _KAFKA.fields_by_name['sasl_jaas_config']._options = None
-  _KAFKA.fields_by_name['sasl_jaas_config']._serialized_options = b'\030\001'
-  _KAFKA.fields_by_name['group_id']._options = None
-  _KAFKA.fields_by_name['group_id']._serialized_options = b'\030\001'
-  _globals['_CDCSTRATEGY']._serialized_start=3767
-  _globals['_CDCSTRATEGY']._serialized_end=3842
-  _globals['_EXTDATABASE']._serialized_start=179
-  _globals['_EXTDATABASE']._serialized_end=679
-  _globals['_KAFKAFORMAT']._serialized_start=682
-  _globals['_KAFKAFORMAT']._serialized_end=810
-  _globals['_JSONFORMAT']._serialized_start=812
-  _globals['_JSONFORMAT']._serialized_end=824
-  _globals['_AVROFORMAT']._serialized_start=826
-  _globals['_AVROFORMAT']._serialized_end=909
-  _globals['_REFERENCE']._serialized_start=912
-  _globals['_REFERENCE']._serialized_end=1096
-  _globals['_REFERENCE_EXTDBTYPE']._serialized_start=986
-  _globals['_REFERENCE_EXTDBTYPE']._serialized_end=1096
-  _globals['_WEBHOOK']._serialized_start=1098
-  _globals['_WEBHOOK']._serialized_end=1121
-  _globals['_MYSQL']._serialized_start=1123
-  _globals['_MYSQL']._serialized_end=1229
-  _globals['_POSTGRES']._serialized_start=1231
-  _globals['_POSTGRES']._serialized_end=1340
-  _globals['_S3']._serialized_start=1342
-  _globals['_S3']._serialized_end=1404
-  _globals['_BIGQUERY']._serialized_start=1406
-  _globals['_BIGQUERY']._serialized_end=1479
-  _globals['_SNOWFLAKE']._serialized_start=1482
-  _globals['_SNOWFLAKE']._serialized_end=1630
-  _globals['_KAFKA']._serialized_start=1633
-  _globals['_KAFKA']._serialized_end=1901
-  _globals['_KINESIS']._serialized_start=1903
-  _globals['_KINESIS']._serialized_end=1930
-  _globals['_EXTTABLE']._serialized_start=1933
-  _globals['_EXTTABLE']._serialized_end=2442
-  _globals['_MYSQLTABLE']._serialized_start=2444
-  _globals['_MYSQLTABLE']._serialized_end=2525
-  _globals['_POSTGRESTABLE']._serialized_start=2527
-  _globals['_POSTGRESTABLE']._serialized_end=2611
-  _globals['_S3TABLE']._serialized_start=2614
-  _globals['_S3TABLE']._serialized_end=2764
-  _globals['_KAFKATOPIC']._serialized_start=2767
-  _globals['_KAFKATOPIC']._serialized_end=2896
-  _globals['_BIGQUERYTABLE']._serialized_start=2898
-  _globals['_BIGQUERYTABLE']._serialized_end=2982
-  _globals['_SNOWFLAKETABLE']._serialized_start=2984
-  _globals['_SNOWFLAKETABLE']._serialized_end=3069
-  _globals['_WEBHOOKENDPOINT']._serialized_start=3071
-  _globals['_WEBHOOKENDPOINT']._serialized_end=3155
-  _globals['_KINESISSTREAM']._serialized_start=3158
-  _globals['_KINESISSTREAM']._serialized_end=3369
-  _globals['_SOURCE']._serialized_start=3372
-  _globals['_SOURCE']._serialized_end=3691
-  _globals['_SINK']._serialized_start=3693
-  _globals['_SINK']._serialized_end=3765
+  _globals['_KAFKA'].fields_by_name['sasl_jaas_config']._options = None
+  _globals['_KAFKA'].fields_by_name['sasl_jaas_config']._serialized_options = b'\030\001'
+  _globals['_KAFKA'].fields_by_name['group_id']._options = None
+  _globals['_KAFKA'].fields_by_name['group_id']._serialized_options = b'\030\001'
+  _globals['_SOURCE_PREPROCENTRY']._options = None
+  _globals['_SOURCE_PREPROCENTRY']._serialized_options = b'8\001'
+  _globals['_CDCSTRATEGY']._serialized_start=4017
+  _globals['_CDCSTRATEGY']._serialized_end=4092
+  _globals['_EXTDATABASE']._serialized_start=193
+  _globals['_EXTDATABASE']._serialized_end=693
+  _globals['_KAFKAFORMAT']._serialized_start=696
+  _globals['_KAFKAFORMAT']._serialized_end=824
+  _globals['_JSONFORMAT']._serialized_start=826
+  _globals['_JSONFORMAT']._serialized_end=838
+  _globals['_AVROFORMAT']._serialized_start=840
+  _globals['_AVROFORMAT']._serialized_end=923
+  _globals['_REFERENCE']._serialized_start=926
+  _globals['_REFERENCE']._serialized_end=1110
+  _globals['_REFERENCE_EXTDBTYPE']._serialized_start=1000
+  _globals['_REFERENCE_EXTDBTYPE']._serialized_end=1110
+  _globals['_WEBHOOK']._serialized_start=1112
+  _globals['_WEBHOOK']._serialized_end=1135
+  _globals['_MYSQL']._serialized_start=1137
+  _globals['_MYSQL']._serialized_end=1243
+  _globals['_POSTGRES']._serialized_start=1245
+  _globals['_POSTGRES']._serialized_end=1354
+  _globals['_S3']._serialized_start=1356
+  _globals['_S3']._serialized_end=1418
+  _globals['_BIGQUERY']._serialized_start=1420
+  _globals['_BIGQUERY']._serialized_end=1493
+  _globals['_SNOWFLAKE']._serialized_start=1496
+  _globals['_SNOWFLAKE']._serialized_end=1644
+  _globals['_KAFKA']._serialized_start=1647
+  _globals['_KAFKA']._serialized_end=1915
+  _globals['_KINESIS']._serialized_start=1917
+  _globals['_KINESIS']._serialized_end=1944
+  _globals['_EXTTABLE']._serialized_start=1947
+  _globals['_EXTTABLE']._serialized_end=2456
+  _globals['_MYSQLTABLE']._serialized_start=2458
+  _globals['_MYSQLTABLE']._serialized_end=2539
+  _globals['_POSTGRESTABLE']._serialized_start=2541
+  _globals['_POSTGRESTABLE']._serialized_end=2625
+  _globals['_S3TABLE']._serialized_start=2628
+  _globals['_S3TABLE']._serialized_end=2778
+  _globals['_KAFKATOPIC']._serialized_start=2781
+  _globals['_KAFKATOPIC']._serialized_end=2910
+  _globals['_BIGQUERYTABLE']._serialized_start=2912
+  _globals['_BIGQUERYTABLE']._serialized_end=2996
+  _globals['_SNOWFLAKETABLE']._serialized_start=2998
+  _globals['_SNOWFLAKETABLE']._serialized_end=3083
+  _globals['_WEBHOOKENDPOINT']._serialized_start=3085
+  _globals['_WEBHOOKENDPOINT']._serialized_end=3169
+  _globals['_KINESISSTREAM']._serialized_start=3172
+  _globals['_KINESISSTREAM']._serialized_end=3383
+  _globals['_PREPROCVALUE']._serialized_start=3385
+  _globals['_PREPROCVALUE']._serialized_end=3470
+  _globals['_SOURCE']._serialized_start=3473
+  _globals['_SOURCE']._serialized_end=3941
+  _globals['_SOURCE_PREPROCENTRY']._serialized_start=3846
+  _globals['_SOURCE_PREPROCENTRY']._serialized_end=3930
+  _globals['_SINK']._serialized_start=3943
+  _globals['_SINK']._serialized_end=4015
 # @@protoc_insertion_point(module_scope)

--- a/fennel/gen/connector_pb2.pyi
+++ b/fennel/gen/connector_pb2.pyi
@@ -12,13 +12,16 @@ database
 5. This whole module is called connector.
 """
 import builtins
+import collections.abc
 import google.protobuf.descriptor
 import google.protobuf.duration_pb2
+import google.protobuf.internal.containers
 import google.protobuf.internal.enum_type_wrapper
 import google.protobuf.message
 import google.protobuf.timestamp_pb2
 import google.protobuf.wrappers_pb2
 import kinesis_pb2
+import schema_pb2
 import schema_registry_pb2
 import sys
 import typing
@@ -642,6 +645,27 @@ class KinesisStream(google.protobuf.message.Message):
 global___KinesisStream = KinesisStream
 
 @typing_extensions.final
+class PreProcValue(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    REF_FIELD_NUMBER: builtins.int
+    VALUE_FIELD_NUMBER: builtins.int
+    ref: builtins.str
+    @property
+    def value(self) -> schema_pb2.Value: ...
+    def __init__(
+        self,
+        *,
+        ref: builtins.str = ...,
+        value: schema_pb2.Value | None = ...,
+    ) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["ref", b"ref", "value", b"value", "variant", b"variant"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["ref", b"ref", "value", b"value", "variant", b"variant"]) -> None: ...
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["variant", b"variant"]) -> typing_extensions.Literal["ref", "value"] | None: ...
+
+global___PreProcValue = PreProcValue
+
+@typing_extensions.final
 class Source(google.protobuf.message.Message):
     """-----------------------------------------
     Finally, all the sources and sinks
@@ -649,6 +673,24 @@ class Source(google.protobuf.message.Message):
     """
 
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+    @typing_extensions.final
+    class PreProcEntry(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+
+        KEY_FIELD_NUMBER: builtins.int
+        VALUE_FIELD_NUMBER: builtins.int
+        key: builtins.str
+        @property
+        def value(self) -> global___PreProcValue: ...
+        def __init__(
+            self,
+            *,
+            key: builtins.str = ...,
+            value: global___PreProcValue | None = ...,
+        ) -> None: ...
+        def HasField(self, field_name: typing_extensions.Literal["value", b"value"]) -> builtins.bool: ...
+        def ClearField(self, field_name: typing_extensions.Literal["key", b"key", "value", b"value"]) -> None: ...
 
     TABLE_FIELD_NUMBER: builtins.int
     DATASET_FIELD_NUMBER: builtins.int
@@ -658,6 +700,7 @@ class Source(google.protobuf.message.Message):
     TIMESTAMP_FIELD_FIELD_NUMBER: builtins.int
     CDC_FIELD_NUMBER: builtins.int
     STARTING_FROM_FIELD_NUMBER: builtins.int
+    PRE_PROC_FIELD_NUMBER: builtins.int
     @property
     def table(self) -> global___ExtTable: ...
     dataset: builtins.str
@@ -670,6 +713,8 @@ class Source(google.protobuf.message.Message):
     cdc: global___CDCStrategy.ValueType
     @property
     def starting_from(self) -> google.protobuf.timestamp_pb2.Timestamp: ...
+    @property
+    def pre_proc(self) -> google.protobuf.internal.containers.MessageMap[builtins.str, global___PreProcValue]: ...
     def __init__(
         self,
         *,
@@ -681,9 +726,10 @@ class Source(google.protobuf.message.Message):
         timestamp_field: builtins.str = ...,
         cdc: global___CDCStrategy.ValueType = ...,
         starting_from: google.protobuf.timestamp_pb2.Timestamp | None = ...,
+        pre_proc: collections.abc.Mapping[builtins.str, global___PreProcValue] | None = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["_cursor", b"_cursor", "cursor", b"cursor", "every", b"every", "lateness", b"lateness", "starting_from", b"starting_from", "table", b"table"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["_cursor", b"_cursor", "cdc", b"cdc", "cursor", b"cursor", "dataset", b"dataset", "every", b"every", "lateness", b"lateness", "starting_from", b"starting_from", "table", b"table", "timestamp_field", b"timestamp_field"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_cursor", b"_cursor", "cdc", b"cdc", "cursor", b"cursor", "dataset", b"dataset", "every", b"every", "lateness", b"lateness", "pre_proc", b"pre_proc", "starting_from", b"starting_from", "table", b"table", "timestamp_field", b"timestamp_field"]) -> None: ...
     def WhichOneof(self, oneof_group: typing_extensions.Literal["_cursor", b"_cursor"]) -> typing_extensions.Literal["cursor"] | None: ...
 
 global___Source = Source

--- a/fennel/gen/dataset_pb2.py
+++ b/fennel/gen/dataset_pb2.py
@@ -24,16 +24,15 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'dataset_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
-  _COREDATASET_FIELDMETADATAENTRY._options = None
-  _COREDATASET_FIELDMETADATAENTRY._serialized_options = b'8\001'
-  _JOIN_ONENTRY._options = None
-  _JOIN_ONENTRY._serialized_options = b'8\001'
-  _TRANSFORM_SCHEMAENTRY._options = None
-  _TRANSFORM_SCHEMAENTRY._serialized_options = b'8\001'
-  _RENAME_COLUMNMAPENTRY._options = None
-  _RENAME_COLUMNMAPENTRY._serialized_options = b'8\001'
+  _globals['_COREDATASET_FIELDMETADATAENTRY']._options = None
+  _globals['_COREDATASET_FIELDMETADATAENTRY']._serialized_options = b'8\001'
+  _globals['_JOIN_ONENTRY']._options = None
+  _globals['_JOIN_ONENTRY']._serialized_options = b'8\001'
+  _globals['_TRANSFORM_SCHEMAENTRY']._options = None
+  _globals['_TRANSFORM_SCHEMAENTRY']._serialized_options = b'8\001'
+  _globals['_RENAME_COLUMNMAPENTRY']._options = None
+  _globals['_RENAME_COLUMNMAPENTRY']._serialized_options = b'8\001'
   _globals['_COREDATASET']._serialized_start=128
   _globals['_COREDATASET']._serialized_end=710
   _globals['_COREDATASET_FIELDMETADATAENTRY']._serialized_start=625

--- a/fennel/gen/expectations_pb2.py
+++ b/fennel/gen/expectations_pb2.py
@@ -20,7 +20,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'expectations_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_EXPECTATIONS']._serialized_start=66
   _globals['_EXPECTATIONS']._serialized_end=385

--- a/fennel/gen/featureset_pb2.py
+++ b/fennel/gen/featureset_pb2.py
@@ -22,7 +22,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'featureset_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_EXTRACTORTYPE']._serialized_start=1204
   _globals['_EXTRACTORTYPE']._serialized_end=1255

--- a/fennel/gen/format_pb2.py
+++ b/fennel/gen/format_pb2.py
@@ -19,7 +19,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'format_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_FILEFORMAT']._serialized_start=38
   _globals['_FILEFORMAT']._serialized_end=474

--- a/fennel/gen/http_auth_pb2.py
+++ b/fennel/gen/http_auth_pb2.py
@@ -20,7 +20,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'http_auth_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_HTTPAUTHENTICATION']._serialized_start=76
   _globals['_HTTPAUTHENTICATION']._serialized_end=231

--- a/fennel/gen/kinesis_pb2.py
+++ b/fennel/gen/kinesis_pb2.py
@@ -19,7 +19,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'kinesis_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_INITPOSITION']._serialized_start=39
   _globals['_INITPOSITION']._serialized_end=101

--- a/fennel/gen/metadata_pb2.py
+++ b/fennel/gen/metadata_pb2.py
@@ -19,7 +19,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'metadata_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_METADATA']._serialized_start=41
   _globals['_METADATA']._serialized_end=138

--- a/fennel/gen/pycode_pb2.py
+++ b/fennel/gen/pycode_pb2.py
@@ -19,10 +19,9 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'pycode_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
-  _PYCODE_REFINCLUDESENTRY._options = None
-  _PYCODE_REFINCLUDESENTRY._serialized_options = b'8\001'
+  _globals['_PYCODE_REFINCLUDESENTRY']._options = None
+  _globals['_PYCODE_REFINCLUDESENTRY']._serialized_options = b'8\001'
   _globals['_REFTYPE']._serialized_start=347
   _globals['_REFTYPE']._serialized_end=385
   _globals['_PYCODE']._serialized_start=38

--- a/fennel/gen/schema_pb2.py
+++ b/fennel/gen/schema_pb2.py
@@ -20,7 +20,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'schema_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_DATATYPE']._serialized_start=71
   _globals['_DATATYPE']._serialized_end=807

--- a/fennel/gen/schema_registry_pb2.py
+++ b/fennel/gen/schema_registry_pb2.py
@@ -20,7 +20,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'schema_registry_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_REGISTRYPROVIDER']._serialized_start=237
   _globals['_REGISTRYPROVIDER']._serialized_end=270

--- a/fennel/gen/services_pb2.py
+++ b/fennel/gen/services_pb2.py
@@ -23,7 +23,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'services_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_SYNCREQUEST']._serialized_start=112
   _globals['_SYNCREQUEST']._serialized_end=664

--- a/fennel/gen/spec_pb2.py
+++ b/fennel/gen/spec_pb2.py
@@ -20,7 +20,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'spec_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_PRESPEC']._serialized_start=48
   _globals['_PRESPEC']._serialized_end=413

--- a/fennel/gen/status_pb2.py
+++ b/fennel/gen/status_pb2.py
@@ -20,9 +20,8 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'status_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
-  DESCRIPTOR._options = None
-  DESCRIPTOR._serialized_options = b'\n\016com.google.rpcB\013StatusProtoP\001Z7google.golang.org/genproto/googleapis/rpc/status;status\370\001\001\242\002\003RPC'
+  _globals['DESCRIPTOR']._options = None
+  _globals['DESCRIPTOR']._serialized_options = b'\n\016com.google.rpcB\013StatusProtoP\001Z7google.golang.org/genproto/googleapis/rpc/status;status\370\001\001\242\002\003RPC'
   _globals['_STATUS']._serialized_start=64
   _globals['_STATUS']._serialized_end=142
 # @@protoc_insertion_point(module_scope)

--- a/fennel/gen/window_pb2.py
+++ b/fennel/gen/window_pb2.py
@@ -20,7 +20,6 @@ _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'window_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-
   DESCRIPTOR._options = None
   _globals['_WINDOW']._serialized_start=69
   _globals['_WINDOW']._serialized_end=186

--- a/fennel/sources/__init__.py
+++ b/fennel/sources/__init__.py
@@ -20,4 +20,7 @@ from fennel.sources.sources import (
     InitPosition,
     KinesisConnector,
     Avro,
+    Ref,
+    ref,
+    PreProcValue,
 )

--- a/fennel/sources/sources.py
+++ b/fennel/sources/sources.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 from enum import Enum
 
-from typing import Any, Callable, List, Optional, TypeVar, Union, Tuple
+from typing import Any, Callable, List, Optional, TypeVar, Union, Tuple, Dict
 
 from fennel._vendor.pydantic import BaseModel  # type: ignore
 from fennel._vendor.pydantic import validator  # type: ignore
@@ -24,6 +24,15 @@ DEFAULT_CDC = "append"
 # ------------------------------------------------------------------------------
 # source & sink decorators
 # ------------------------------------------------------------------------------
+class Ref(BaseModel):
+    name: str
+
+
+def ref(ref_name: str) -> PreProcValue:
+    return Ref(name=ref_name)
+
+
+PreProcValue = Union[Ref, Any]
 
 
 def source(
@@ -33,6 +42,7 @@ def source(
     lateness: Optional[Duration] = None,
     cdc: Optional[str] = None,
     tier: Optional[Union[str, List[str]]] = None,
+    pre_proc: Optional[Dict[str, PreProcValue]] = None,
 ) -> Callable[[T], Any]:
     if not isinstance(conn, DataConnector):
         if not isinstance(conn, DataSource):
@@ -51,6 +61,7 @@ def source(
         conn.cdc = cdc if cdc is not None else DEFAULT_CDC
         conn.starting_from = since
         conn.tiers = TierSelector(tier)
+        conn.pre_proc = pre_proc
         connectors = getattr(dataset_cls, SOURCE_FIELD, [])
         connectors.append(conn)
         setattr(dataset_cls, SOURCE_FIELD, connectors)
@@ -366,6 +377,7 @@ class DataConnector:
     cdc: str
     starting_from: Optional[datetime] = None
     tiers: TierSelector
+    pre_proc: Optional[Dict[str, PreProcValue]] = None
 
     def identifier(self):
         raise NotImplementedError

--- a/fennel/sources/test_sources.py
+++ b/fennel/sources/test_sources.py
@@ -18,6 +18,7 @@ from fennel.sources import (
     Kinesis,
     InitPosition,
     Avro,
+    ref,
 )
 
 # noinspection PyUnresolvedReferences
@@ -148,6 +149,165 @@ def test_simple_source():
         "lateness": "72000s",
         "cursor": "added_on",
         "timestamp_field": "timestamp",
+    }
+    expected_source_request = ParseDict(s, connector_proto.Source())
+    assert source_request == expected_source_request, error_message(
+        source_request, expected_source_request
+    )
+
+    # External DBs
+    assert len(sync_request.extdbs) == 1
+    extdb_request = sync_request.extdbs[0]
+    e = {
+        "name": "mysql",
+        "mysql": {
+            "host": "localhost",
+            "database": "test",
+            "user": "root",
+            "password": "root",
+            "port": 3306,
+        },
+    }
+    expected_extdb_request = ParseDict(e, connector_proto.ExtDatabase())
+    assert extdb_request == expected_extdb_request, error_message(
+        extdb_request, expected_extdb_request
+    )
+
+
+def test_simple_source_with_pre_proc():
+    @source(
+        mysql.table(
+            "users",
+            cursor="added_on",
+        ),
+        every="1h",
+        lateness="20h",
+        pre_proc={
+            "age": 10,
+            "timestamp": datetime(1970, 1, 1, 0, 0, 0),
+            "country": ref("upstream.country"),
+        },
+    )
+    @meta(owner="test@test.com")
+    @dataset
+    class UserInfoDataset:
+        user_id: int = field(key=True)
+        name: str
+        gender: str
+        # Users date of birth
+        dob: str
+        age: int
+        account_creation_date: datetime
+        country: Optional[str]
+        timestamp: datetime = field(timestamp=True)
+
+    view = InternalTestClient()
+    view.add(UserInfoDataset)
+    sync_request = view._get_sync_request_proto()
+    assert len(sync_request.datasets) == 1
+    assert len(sync_request.sources) == 1
+    dataset_request = sync_request.datasets[0]
+    d = {
+        "name": "UserInfoDataset",
+        "dsschema": {
+            "keys": {
+                "fields": [
+                    {
+                        "name": "user_id",
+                        "dtype": {"int_type": {}},
+                    }
+                ],
+            },
+            "values": {
+                "fields": [
+                    {
+                        "name": "name",
+                        "dtype": {"string_type": {}},
+                    },
+                    {
+                        "name": "gender",
+                        "dtype": {"string_type": {}},
+                    },
+                    {
+                        "name": "dob",
+                        "dtype": {"string_type": {}},
+                    },
+                    {
+                        "name": "age",
+                        "dtype": {"int_type": {}},
+                    },
+                    {
+                        "name": "account_creation_date",
+                        "dtype": {"timestamp_type": {}},
+                    },
+                    {
+                        "name": "country",
+                        "dtype": {"optional_type": {"of": {"string_type": {}}}},
+                    },
+                ]
+            },
+            "timestamp": "timestamp",
+        },
+        "metadata": {
+            "owner": "test@test.com",
+        },
+        "history": "63072000s",
+        "retention": "63072000s",
+        "field_metadata": {
+            "user_id": {},
+            "name": {},
+            "gender": {},
+            "dob": {"description": "Users date of birth"},
+            "age": {},
+            "account_creation_date": {},
+            "country": {},
+            "timestamp": {},
+        },
+        "isSourceDataset": True,
+    }
+    expected_dataset_request = ParseDict(d, ds_proto.CoreDataset())
+    expected_dataset_request.pycode.Clear()
+    dataset_request.pycode.Clear()
+    assert dataset_request == expected_dataset_request, error_message(
+        dataset_request, expected_dataset_request
+    )
+
+    assert len(sync_request.sources) == 1
+    source_request = sync_request.sources[0]
+    s = {
+        "table": {
+            "mysql_table": {
+                "db": {
+                    "name": "mysql",
+                    "mysql": {
+                        "host": "localhost",
+                        "database": "test",
+                        "user": "root",
+                        "password": "root",
+                        "port": 3306,
+                    },
+                },
+                "table_name": "users",
+            },
+        },
+        "dataset": "UserInfoDataset",
+        "every": "3600s",
+        "lateness": "72000s",
+        "cursor": "added_on",
+        "timestamp_field": "timestamp",
+        "pre_proc": {
+            "age": {
+                "value": {
+                    "int": 10,
+                },
+            },
+            "country": {
+                "ref": "upstream.country",
+            },
+            "timestamp": {
+                "value": {"timestamp": "1970-01-01T00:00:00Z"},
+            },
+        },
     }
     expected_source_request = ParseDict(s, connector_proto.Source())
     assert source_request == expected_source_request, error_message(


### PR DESCRIPTION
This will allow the following workflows -
1. If a column doesn't exist in the upstream data source, the user could specify a constant value or refer to an existing column name.
2. If a column name in the data source is not a valid python variable (e.g. has  in the name etc), allow referencing to the column with such names.

TODO: extending types for the `pre_proc` values. Currently limiting to the ones which are frequently used.