### PR TITLE
[DEV-2653] Fixed DOB calculation logic in documentation and tests

### DIFF
--- a/docs/examples/overview/concepts.py
+++ b/docs/examples/overview/concepts.py
@@ -105,7 +105,7 @@ class UserFeature:
     @outputs(age)
     def get_age(cls, ts: pd.Series, uids: pd.Series):
         dobs = User.lookup(ts=ts, uid=uids, fields=["dob"])
-        ages = [dob - datetime.now() for dob in dobs]
+        ages = ts - dobs
         return pd.Series(ages)
 
     @extractor

--- a/docs/examples/overview/concepts.py
+++ b/docs/examples/overview/concepts.py
@@ -105,6 +105,7 @@ class UserFeature:
     @outputs(age)
     def get_age(cls, ts: pd.Series, uids: pd.Series):
         dobs = User.lookup(ts=ts, uid=uids, fields=["dob"])
+        # Using ts instead of datetime.now() to make extract_historical work as of for the extractor
         ages = ts - dobs
         return pd.Series(ages)
 

--- a/fennel/lib/to_proto/test_source_code.py
+++ b/fennel/lib/to_proto/test_source_code.py
@@ -88,6 +88,7 @@ class UserFeature:
     @outputs(age)
     def get_age(cls, ts: pd.Series, uids: pd.Series):
         dobs = User.lookup(ts=ts, uid=uids, fields=["dob"])  # type: ignore
+        # Using ts instead of datetime.now() to make extract_historical work as of for the extractor
         ages = ts - dobs
         return pd.Series(ages)
 

--- a/fennel/lib/to_proto/test_source_code.py
+++ b/fennel/lib/to_proto/test_source_code.py
@@ -88,7 +88,7 @@ class UserFeature:
     @outputs(age)
     def get_age(cls, ts: pd.Series, uids: pd.Series):
         dobs = User.lookup(ts=ts, uid=uids, fields=["dob"])  # type: ignore
-        ages = [dob - datetime.now() for dob in dobs]
+        ages = ts - dobs
         return pd.Series(ages)
 
     @extractor(depends_on=[User])


### PR DESCRIPTION
Using ts instead of datetime.now() to make extract_historical use as of time instead of always using current time.