### PR TITLE
DEV-2947 DEV-2948 Allow JSONL format for s3 sources

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -97,6 +97,8 @@ ith
 jdbc
 JSON
 json
+JSONL
+jsonl
 JSX
 JVM
 kafka

--- a/docs/pages/api-reference/sources.md
+++ b/docs/pages/api-reference/sources.md
@@ -75,7 +75,7 @@ The following fields need to be defined on the bucket:
    files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many
    folders/files&#x20;
 3. **`format`** (optional) - The format of the files you'd like to replicate. You can choose between CSV (default),
-   Avro, Hudi, Parquet, JSON and JSONL. For newline-delimitted JSON records, choose JSONL. &#x20;
+   Avro, Hudi, Parquet, JSON and JSONL. For newline-delimited JSON records, choose JSONL. &#x20;
 4. **`delimiter`** (optional) - the character delimiting individual cells in the CSV data. The default value is `","`
    and if overridden, this can only be a 1-character string. For example, to use tab-delimited data enter `"\t"`.
 

--- a/docs/pages/api-reference/sources.md
+++ b/docs/pages/api-reference/sources.md
@@ -75,7 +75,7 @@ The following fields need to be defined on the bucket:
    files sit, we can optimize finding these in S3. This is optional but recommended if your bucket contains many
    folders/files&#x20;
 3. **`format`** (optional) - The format of the files you'd like to replicate. You can choose between CSV (default),
-   Avro, Hudi and Parquet.&#x20;
+   Avro, Hudi, Parquet, JSON and JSONL. For newline-delimitted JSON records, choose JSONL. &#x20;
 4. **`delimiter`** (optional) - the character delimiting individual cells in the CSV data. The default value is `","`
    and if overridden, this can only be a 1-character string. For example, to use tab-delimited data enter `"\t"`.
 

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.20.11] - 2024-01-24
+- Enable JSONL (newline-delimitted json) as an allowed format for S3 
+
 ## [0.20.10] - 2024-01-22
 - Added capability in lookup method in client to support as-of lookups on keyed datasets.
 

--- a/fennel/sources/sources.py
+++ b/fennel/sources/sources.py
@@ -452,10 +452,17 @@ class S3Connector(DataConnector):
         self.format = format
         self.presorted = presorted
 
-        if self.format not in ["csv", "json", "parquet", "hudi", "delta"]:
+        if self.format not in [
+            "csv",
+            "json",
+            "jsonl",
+            "parquet",
+            "hudi",
+            "delta",
+        ]:
             raise (
                 ValueError(
-                    "format must be either csv, json, parquet, hudi, delta"
+                    "format must be either csv, json, jsonl, parquet, hudi, delta"
                 )
             )
         if self.format == "csv" and self.delimiter not in [",", "\t", "|"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.20.10"
+version = "0.20.11"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
Note this PR is doing the bare minimum to make sure that `jsonl` works as a batch format for S3 for blackcrow. I haven't checked for other batch sources 

Doc Update:
<img width="1016" alt="image" src="https://github.com/fennel-ai/client/assets/8029573/8c43e15f-ca4f-4972-9466-032a2ea7cd82">

