### PR TITLE
[HOT FIX] Improved casting to timestamp in case of epoch

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [0.20.15] - 2024-01-30
+- Improved casting to timestamp in case of epoch
+
 ## [0.20.14] - 2024-01-29
 - Support `since` for all source types in the client
 - Allow directly specifying a timestamp kinesis init_position instead of forcing the

--- a/fennel/datasets/test_dataset_lookup.py
+++ b/fennel/datasets/test_dataset_lookup.py
@@ -31,7 +31,7 @@ class UserInfoDataset:
 def fake_func(
     cls_name: str, ts: pd.Series, fields: List[str], df: pd.DataFrame
 ):
-    now = datetime.fromtimestamp(1668368655)
+    now = datetime.utcfromtimestamp(1668368655)
     if len(fields) > 0:
         assert ts.equals(pd.Series([now, now, now]))
         assert fields == ["age", "gender"]
@@ -107,7 +107,7 @@ def test_dataset_lookup():
     assert user_sq_extractor.name == "user_age_sq"
 
     user_sq_extractor_func = get_extractor_func(sync_request.extractors[1])
-    now = datetime.fromtimestamp(1668368655)
+    now = datetime.utcfromtimestamp(1668368655)
     ts = pd.Series([now, now, now])
     user_id = pd.Series([1, 2, 3])
     names = pd.Series(["a", "b", "c"])

--- a/fennel/datasets/test_invalid_dataset.py
+++ b/fennel/datasets/test_invalid_dataset.py
@@ -953,9 +953,9 @@ def test_invalid_assign_schema(client):
             "latitude": [1.12312, 2.3423423, 2.24343],
             "longitude": [1.12312, 2.3423423, 2.24343],
             "created": [
-                datetime.fromtimestamp(1672858163),
-                datetime.fromtimestamp(1672858163),
-                datetime.fromtimestamp(1672858163),
+                datetime.utcfromtimestamp(1672858163),
+                datetime.utcfromtimestamp(1672858163),
+                datetime.utcfromtimestamp(1672858163),
             ],
         }
     )

--- a/fennel/sources/kinesis.py
+++ b/fennel/sources/kinesis.py
@@ -22,7 +22,7 @@ class at_timestamp(object):
         if isinstance(timestamp, datetime):
             self.timestamp = timestamp
         elif isinstance(timestamp, (int, float)):
-            self.timestamp = datetime.fromtimestamp(timestamp)
+            self.timestamp = datetime.utcfromtimestamp(timestamp)
         elif isinstance(timestamp, str):
             self.timestamp = datetime.fromisoformat(timestamp)
         else:

--- a/fennel/test_lib/mock_client.py
+++ b/fennel/test_lib/mock_client.py
@@ -910,9 +910,9 @@ class MockClient(Client):
             features = self.features_for_fs[extractor.featureset]
             feature_schema = {}
             for feature in features:
-                feature_schema[
-                    f"{extractor.featureset}.{feature.name}"
-                ] = feature.dtype
+                feature_schema[f"{extractor.featureset}.{feature.name}"] = (
+                    feature.dtype
+                )
             fields = []
             for feature_str in extractor.output_features:
                 feature_str = f"{extractor.featureset}.{feature_str}"

--- a/fennel/test_lib/test_cast_df_to_schema.py
+++ b/fennel/test_lib/test_cast_df_to_schema.py
@@ -179,7 +179,7 @@ def test_cast_invalid_timestamp():
         cast_df_to_schema(df, schema)
     assert (
         str(e.value)
-        == """Failed to cast data logged to timestamp column created_ts: Unknown string format: not a timestamp present at position 3"""
+        == """Failed to cast data logged to timestamp column created_ts: Unknown string format: not a timestamp present at position 0"""
     )
 
 

--- a/fennel/test_lib/test_utils.py
+++ b/fennel/test_lib/test_utils.py
@@ -1,5 +1,7 @@
+from datetime import datetime
+
 from math import isnan
-from typing import Any
+from typing import Any, Union
 import pandas as pd
 import numpy as np
 from fennel._vendor import jsondiff  # type: ignore
@@ -103,7 +105,7 @@ def cast_col_to_dtype(series: pd.Series, dtype) -> pd.Series:
     elif dtype.HasField("bool_type"):
         return series.astype(pd.BooleanDtype())
     elif dtype.HasField("timestamp_type"):
-        return pd.to_datetime(series)
+        return pd.to_datetime(series.apply(lambda x: parse_datetime(x)))
     elif dtype.HasField("optional_type"):
         # Those fields which are not null should be casted to the right type
         if series.notnull().any():
@@ -128,3 +130,15 @@ def cast_col_to_dtype(series: pd.Series, dtype) -> pd.Series:
     elif dtype.HasField("between_type"):
         return cast_col_to_dtype(series, dtype.between_type.dtype)
     return series
+
+
+def parse_datetime(value: Union[int, str, datetime]) -> datetime:
+    if isinstance(value, int):
+        try:
+            return pd.to_datetime(value, unit="s")
+        except ValueError:
+            try:
+                return pd.to_datetime(value, unit="ms")
+            except ValueError:
+                return pd.to_datetime(value, unit="us")
+    return pd.to_datetime(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "0.20.14"
+version = "0.20.15"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
1. Improved casting to timestamp from epoch time while logging into datasets.
2. Change fromtimestamp to utcfromtimestamp everywhere in the codebase.