### PR TITLE
Fix broken reference to kafka_sinks example file

### DIFF
--- a/docs/pages/api-reference/connectors/kafka.md
+++ b/docs/pages/api-reference/connectors/kafka.md
@@ -54,7 +54,7 @@ The format of the data in Kafka topic. Both `"json"` and
     status="success" message="Sourcing json data from kafka to a dataset"
 ></pre>
 
-<pre snippet="api-reference/sinks/kafka#basic"
+<pre snippet="api-reference/sinks/kafka_sinks#basic"
     status="success" message="Capturing change from a dataset to a Kafka Sink"
 ></pre>
 


### PR DESCRIPTION
builds are currently failing due to an incorrect reference to the `kafka_sinks` example file