### PR TITLE
[DEV 3871] Added capability to pass Dataset in lookup and inspect

### DIFF
--- a/docs/examples/api-reference/client.py
+++ b/docs/examples/api-reference/client.py
@@ -127,7 +127,7 @@ class TestExtractorDAGResolution(unittest.TestCase):
 
         # docsnip lookup
         response = client.lookup(
-            dataset_name="UserInfoDataset",
+            dataset="UserInfoDataset",
             keys=pd.DataFrame({"user_id": [18232]}),
             fields=["name"],
         )

--- a/docs/pages/api-reference/client/lookup.md
+++ b/docs/pages/api-reference/client/lookup.md
@@ -9,8 +9,8 @@ status: published
 Method to lookup rows of keyed datasets.
 
 #### Parameters
-<Expandable title="dataset_name" type="str">
-The name of the dataset to be looked up.
+<Expandable title="dataset" type="Union[str, Dataset]">
+The name of the dataset or Dataset object to be looked up.
 </Expandable>
 
 <Expandable title="keys" type="List[Dict[str, Any]]">

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -656,7 +656,7 @@ class Client:
 
     def lookup(
         self,
-        dataset_name: str,
+        dataset: Union[str, Dataset],
         keys: pd.DataFrame,
         fields: Optional[List[str]] = None,
         timestamps: Optional[pd.Series] = None,
@@ -665,7 +665,7 @@ class Client:
 
         Parameters:
         ----------
-        dataset_name (str): The name of the dataset.
+        dataset (Union[str, Dataset]): The name of the dataset or Dataset object.
         keys (pd.DataFrame): All the keys to lookup.
         fields: (Optional[List[str]]): The fields to lookup. If None, all
             fields are returned.
@@ -679,6 +679,7 @@ class Client:
         corresponding key(s) is found in the dataset.
 
         """
+        dataset_name = dataset if isinstance(dataset, str) else dataset._name
         keys = keys.to_dict(orient="records")
         fields = fields if fields else []
         req = {
@@ -705,12 +706,14 @@ class Client:
             )
         return pd.DataFrame(resp_json["data"]), found
 
-    def inspect(self, dataset_name: str, n: int = 10) -> List[Dict[str, Any]]:
+    def inspect(
+        self, dataset: Union[str, Dataset], n: int = 10
+    ) -> List[Dict[str, Any]]:
         """Inspect the last n rows of a dataset.
 
         Parameters:
         ----------
-        dataset_name (str): The dataset name.
+        dataset (str): The name of the dataset or Dataset object.
         n (int): The number of rows, default is 10.
 
         Returns: List[Dict[str, Any]]:
@@ -718,6 +721,7 @@ class Client:
         A list of dataset rows.
 
         """
+        dataset_name = dataset if isinstance(dataset, str) else dataset._name
         return self._get(
             "{}/dataset/{}/inspect?n={}".format(V1_API, dataset_name, n)
         ).json()

--- a/fennel/client_tests/branches/test_clone.py
+++ b/fennel/client_tests/branches/test_clone.py
@@ -210,7 +210,7 @@ def test_clone_after_log(client):
     client.sleep()
 
     _, found = client.lookup(
-        dataset_name="UserInfoDataset",
+        "UserInfoDataset",
         keys=pd.DataFrame({"user_id": [1, 2]}),
     )
     assert found.to_list() == [True, False]
@@ -218,7 +218,7 @@ def test_clone_after_log(client):
     client.clone_branch("test-branch", from_branch="main")
     assert client.branch() == "test-branch"
     _, found = client.lookup(
-        dataset_name="UserInfoDataset",
+        "UserInfoDataset",
         keys=pd.DataFrame({"user_id": [1, 2]}),
     )
     assert found.to_list() == [True, False]
@@ -267,7 +267,7 @@ def test_webhook_log_to_both_clone_parent(client):
 
     assert client.branch() == "test-branch"
     params = {
-        "dataset_name": "GenderStats",
+        "dataset": "GenderStats",
         "keys": pd.DataFrame({"gender": ["male", "F"]}),
         "fields": ["gender", "count"],
     }
@@ -426,7 +426,7 @@ def test_change_dataset_clone_branch(client):
 
     client.checkout("test-branch")
     df, found = client.lookup(
-        dataset_name="GenderStats",
+        "GenderStats",
         keys=pd.DataFrame({"gender": ["male", "F"]}),
         fields=["gender", "count"],
     )
@@ -475,7 +475,7 @@ def test_multiple_clone_branch(client):
     client.sleep()
 
     params = {
-        "dataset_name": "GenderStats",
+        "dataset": "GenderStats",
         "keys": pd.DataFrame({"gender": ["male", "F"]}),
         "fields": ["gender", "count"],
     }
@@ -592,7 +592,7 @@ def test_change_source_dataset_clone_branch(client):
     client.sleep()
 
     params = {
-        "dataset_name": "GenderStats",
+        "dataset": "GenderStats",
         "keys": pd.DataFrame({"gender": [0, 1]}),
         "fields": ["gender", "count"],
     }

--- a/fennel/client_tests/branches/test_create.py
+++ b/fennel/client_tests/branches/test_create.py
@@ -79,7 +79,7 @@ def test_complex_create(client):
     )
 
     _, found = client.lookup(
-        dataset_name="UserInfoDataset",
+        "UserInfoDataset",
         keys=pd.DataFrame({"user_id": [1, 2]}),
         fields=["age"],
     )
@@ -131,7 +131,7 @@ def test_log(client):
     client.sleep()
 
     _, found = client.lookup(
-        dataset_name="UserInfoDataset",
+        "UserInfoDataset",
         keys=pd.DataFrame({"user_id": [1, 2]}),
         fields=["age"],
     )

--- a/fennel/client_tests/test_dataset.py
+++ b/fennel/client_tests/test_dataset.py
@@ -792,7 +792,7 @@ class TestBasicExplode(unittest.TestCase):
 
         # do lookup on the WithSquare dataset
         df, found = client.lookup(
-            dataset_name="Derived",
+            "Derived",
             keys=pd.DataFrame({"uid": [1, 2], "sku": [1, 2]}),
         )
         assert list(found) == [True, False]

--- a/fennel/testing/mock_client.py
+++ b/fennel/testing/mock_client.py
@@ -204,11 +204,12 @@ class MockClient(Client):
 
     def lookup(
         self,
-        dataset_name: str,
+        dataset: Union[str, Dataset],
         keys: pd.DataFrame,
         fields: Optional[List[str]] = None,
         timestamps: Optional[pd.Series] = None,
     ) -> Tuple[Union[pd.DataFrame, pd.Series], pd.Series]:
+        dataset_name = dataset if isinstance(dataset, str) else dataset._name
         branch_class = self._get_branch()
         data_engine = branch_class.get_data_engine()
         return self.query_engine.lookup(
@@ -217,9 +218,10 @@ class MockClient(Client):
 
     def inspect(
         self,
-        dataset_name: str,
+        dataset: Union[str, Dataset],
         n: int = 10,
     ) -> List[Dict[str, Any]]:
+        dataset_name = dataset if isinstance(dataset, str) else dataset._name
         branch_class = self._get_branch()
         df = branch_class.get_dataset_df(dataset_name)
         if df.shape[0] <= n:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `lookup` function to accept either a dataset name as a string or a Dataset object, improving flexibility in dataset handling.

- **Documentation**
  - Updated API reference to reflect the new parameter capabilities in the `lookup` function.

- **Bug Fixes**
  - Corrected parameter naming inconsistencies across various test functions to align with the new `lookup` function signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->