### PR TITLE
[DEV 3875] Changed depends_on with deps with backward compability

### DIFF
--- a/docs/examples/api-reference/client.py
+++ b/docs/examples/api-reference/client.py
@@ -47,7 +47,7 @@ class UserFeatures:
     age_cubed: int
     is_name_common: bool
 
-    @extractor(depends_on=[UserInfoDataset])
+    @extractor(deps=[UserInfoDataset])
     @inputs("userid")
     @outputs("age", "name")
     def get_user_age_and_name(cls, ts: pd.Series, user_id: pd.Series):
@@ -69,7 +69,7 @@ class UserFeatures:
         ]
         return df
 
-    @extractor(depends_on=[UserInfoDataset])
+    @extractor(deps=[UserInfoDataset])
     @includes(get_country_geoid)
     @inputs("userid")
     @outputs("country_geoid")

--- a/docs/examples/concepts/introduction.py
+++ b/docs/examples/concepts/introduction.py
@@ -104,7 +104,7 @@ def test_overview(client):
         dob: datetime
 
         # docsnip-highlight start
-        @extractor(depends_on=[User])
+        @extractor(deps=[User])
         @inputs("uid")
         @outputs("age")
         def get_age(cls, ts: pd.Series, uids: pd.Series):
@@ -115,7 +115,7 @@ def test_overview(client):
 
         # docsnip-highlight end
 
-        @extractor(depends_on=[User])
+        @extractor(deps=[User])
         @inputs("uid")
         @outputs("country")
         def get_country(cls, ts: pd.Series, uids: pd.Series):

--- a/docs/examples/datasets/lookups.py
+++ b/docs/examples/datasets/lookups.py
@@ -30,7 +30,7 @@ class UserFeature:
     name: str
     in_home_city: bool
 
-    @extractor(depends_on=[User])
+    @extractor(deps=[User])
     @inputs("uid")
     @outputs("in_home_city")
     def func(cls, ts: pd.Series, uid: pd.Series):

--- a/docs/examples/examples/ecommerce.py
+++ b/docs/examples/examples/ecommerce.py
@@ -80,7 +80,7 @@ class UserSeller:
     num_orders_1d: int
     num_orders_1w: int
 
-    @extractor(depends_on=[UserSellerOrders])
+    @extractor(deps=[UserSellerOrders])
     @inputs("uid", "seller_id")
     @outputs("num_orders_1d", "num_orders_1w")
     def myextractor(cls, ts: pd.Series, uids: pd.Series, sellers: pd.Series):

--- a/docs/examples/featuresets/overview.py
+++ b/docs/examples/featuresets/overview.py
@@ -197,7 +197,7 @@ def test_multiple_features_extracted(client):
         latitude: float
         longitude: float
 
-        @extractor(depends_on=[UserInfo])
+        @extractor(deps=[UserInfo])
         @inputs("uid")
         @outputs("latitude", "longitude")
         def get_user_city_coordinates(cls, ts: pd.Series, uid: pd.Series):
@@ -275,7 +275,7 @@ def test_extractors_across_featuresets(client):
         latitude: float
         longitude: float
 
-        @extractor(depends_on=[UserInfo])
+        @extractor(deps=[UserInfo])
         @inputs(Request.uid)
         @outputs("uid", "latitude", "longitude")
         def get_country_geoid(cls, ts: pd.Series, uid: pd.Series):

--- a/docs/examples/featuresets/reading_datasets.py
+++ b/docs/examples/featuresets/reading_datasets.py
@@ -30,7 +30,7 @@ class UserFeatures:
     uid: int
     name: str
 
-    @extractor(depends_on=[User])  # docsnip-highlight
+    @extractor(deps=[User])  # docsnip-highlight
     @inputs("uid")
     @outputs("name")
     def func(cls, ts: pd.Series, uids: pd.Series):

--- a/docs/examples/getting-started/quickstart.py
+++ b/docs/examples/getting-started/quickstart.py
@@ -111,7 +111,7 @@ class UserSellerFeatures:
     num_orders_1d: int
     num_orders_1w: int
 
-    @extractor(depends_on=[UserSellerOrders])
+    @extractor(deps=[UserSellerOrders])
     @inputs("uid", "seller_id")
     @outputs("num_orders_1d", "num_orders_1w")
     def myextractor(cls, ts: pd.Series, uids: pd.Series, sellers: pd.Series):

--- a/docs/examples/testing-and-ci-cd/unit_tests.py
+++ b/docs/examples/testing-and-ci-cd/unit_tests.py
@@ -186,7 +186,7 @@ class UserInfoMultipleExtractor:
     age_cubed: int
     is_name_common: bool
 
-    @extractor(depends_on=[UserInfoDataset])
+    @extractor(deps=[UserInfoDataset])
     @inputs("userid")
     @outputs("age", "name")
     def get_user_age_and_name(cls, ts: pd.Series, user_id: pd.Series):
@@ -208,7 +208,7 @@ class UserInfoMultipleExtractor:
         ]
         return df
 
-    @extractor(depends_on=[UserInfoDataset])
+    @extractor(deps=[UserInfoDataset])
     @includes(get_country_geoid)
     @inputs("userid")
     @outputs("country_geoid")

--- a/examples/fraud/featuresets/driver.py
+++ b/examples/fraud/featuresets/driver.py
@@ -20,7 +20,7 @@ class AgeFS:
     account_age: float
     age: float
 
-    @extractor(depends_on=[DriverDS])
+    @extractor(deps=[DriverDS])
     @inputs(Request.driver_id)
     @outputs("account_age", "age")
     def extract(cls, ts: pd.Series, driver_id: pd.Series):
@@ -50,7 +50,7 @@ class ReservationLevelFS:
     )
     trip_duration_hours: float
 
-    @extractor(depends_on=[RentCarCheckoutEventDS])
+    @extractor(deps=[RentCarCheckoutEventDS])
     @inputs(Request.driver_id)
     @outputs("trip_duration_hours")
     def extract(cls, ts: pd.Series, driver_id: pd.Series):

--- a/examples/fraud/featuresets/vehicle.py
+++ b/examples/fraud/featuresets/vehicle.py
@@ -14,7 +14,7 @@ class VehicleFS:
     market_area_id: int = F(MarketAreaDS.market_area_id, default=0)
     vehicle_state: str
 
-    @extractor(depends_on=[MarketAreaDS], version=1)
+    @extractor(deps=[MarketAreaDS], version=1)
     @inputs(vehicle_id)
     @outputs("vehicle_state")
     def extract_vehicle_state(cls, ts: pd.Series, vehicle_ids: pd.Series):

--- a/examples/fraud/featuresets/velocity.py
+++ b/examples/fraud/featuresets/velocity.py
@@ -30,7 +30,7 @@ class DriverVelocityFS:
         PastApprovedDS.num_past_approved_trips, default=0
     )
 
-    @extractor(depends_on=[NumCompletedTripsDS, CancelledTripsDS], version=1)
+    @extractor(deps=[NumCompletedTripsDS, CancelledTripsDS], version=1)
     @inputs(driver_id)
     @outputs("percent_past_guest_cancelled_trips")
     def calculate_percent_past_guest_cancelled_trips(

--- a/fennel/client_tests/branches/test_clone.py
+++ b/fennel/client_tests/branches/test_clone.py
@@ -123,7 +123,7 @@ def _get_changed_featureset():
         country_code: int
         email: str = F(UserInfoDataset.email, default="None")  # type: ignore
 
-        @extractor(depends_on=[UserInfoDataset], version=2)
+        @extractor(deps=[UserInfoDataset], version=2)
         @inputs("user_id")
         @outputs("age", "country_code")
         def my_extractor(cls, ts: pd.Series, user_id: pd.Series):

--- a/fennel/client_tests/test_complex_struct.py
+++ b/fennel/client_tests/test_complex_struct.py
@@ -104,7 +104,7 @@ class MovieFeatures:
     role_list_struct: List[Role]
     movie_budget: MovieBudget
 
-    @extractor(depends_on=[MovieInfo])  # type: ignore
+    @extractor(deps=[MovieInfo])  # type: ignore
     @inputs(Request.director_id, Request.movie_id)
     @outputs("role_list_py")
     def extract_cast(
@@ -114,7 +114,7 @@ class MovieFeatures:
         res = res.rename(columns={"role_list": "role_list_py"})
         return pd.Series(res["role_list_py"].fillna("").apply(list))
 
-    @extractor(depends_on=[MovieInfo])  # type: ignore
+    @extractor(deps=[MovieInfo])  # type: ignore
     @inputs(Request.director_movie_id)
     @outputs("role_list_struct")
     def extract_cast_struct(cls, ts: pd.Series, director_movie_ids: pd.Series):
@@ -126,7 +126,7 @@ class MovieFeatures:
         res = res.rename(columns={"role_list": "role_list_struct"})
         return pd.Series(res["role_list_struct"].fillna("").apply(list))
 
-    @extractor(depends_on=[MovieInfo])  # type: ignore
+    @extractor(deps=[MovieInfo])  # type: ignore
     @inputs(Request.director_id, Request.movie_id)
     @outputs("movie_budget")
     def extract_movie_budget(

--- a/fennel/client_tests/test_featureset.py
+++ b/fennel/client_tests/test_featureset.py
@@ -57,7 +57,7 @@ class UserInfoSingleExtractor:
     age_cubed: int
     is_name_common: bool
 
-    @extractor(depends_on=[UserInfoDataset])  # type: ignore
+    @extractor(deps=[UserInfoDataset])  # type: ignore
     @inputs("userid")
     @outputs("age", "age_squared", "age_cubed", "is_name_common")
     def get_user_info(cls, ts: pd.Series, user_id: pd.Series):
@@ -98,7 +98,7 @@ class UserInfoMultipleExtractor:
     age_reciprocal: float
     age_doubled: int
 
-    @extractor(depends_on=[UserInfoDataset])  # type: ignore
+    @extractor(deps=[UserInfoDataset])  # type: ignore
     @inputs("userid")
     @outputs("age", "name")
     def get_user_age_and_name(cls, ts: pd.Series, user_id: pd.Series):
@@ -140,7 +140,7 @@ class UserInfoMultipleExtractor:
         # returns a dataframe with extra columns
         return pd.DataFrame([d4, d3, d2]).T
 
-    @extractor(depends_on=[UserInfoDataset], version=2)  # type: ignore
+    @extractor(deps=[UserInfoDataset], version=2)  # type: ignore
     @includes(get_country_geoid)
     @inputs("userid")
     @outputs("country_geoid")
@@ -579,7 +579,7 @@ class DocumentFeatures:
     fast_text_embedding: Embedding[3]
     num_words: int
 
-    @extractor(depends_on=[DocumentContentDataset])  # type: ignore
+    @extractor(deps=[DocumentContentDataset])  # type: ignore
     @inputs("doc_id")
     @outputs("num_words", "bert_embedding", "fast_text_embedding")
     def get_doc_features(cls, ts: pd.Series, doc_id: pd.Series):

--- a/fennel/client_tests/test_fraud_detection.py
+++ b/fennel/client_tests/test_fraud_detection.py
@@ -78,7 +78,7 @@ class UserTransactionSumsFeatures:
     sum_amt_7d: float
 
     # If come from different featuresets have to include full path x.y
-    @extractor(depends_on=[UserTransactionSums])  # type: ignore
+    @extractor(deps=[UserTransactionSums])  # type: ignore
     @inputs("cc_num")
     @outputs("sum_amt_1d", "sum_amt_7d")
     def my_extractor(cls, ts: pd.Series, cc_nums: pd.Series):

--- a/fennel/client_tests/test_hopping_window_operator.py
+++ b/fennel/client_tests/test_hopping_window_operator.py
@@ -130,7 +130,7 @@ class UserSessionStats:
     last_visitor_session: List[Window]
     avg_star: float
 
-    @extractor(depends_on=[SessionStats])  # type: ignore
+    @extractor(deps=[SessionStats])  # type: ignore
     @inputs("user_id")
     @outputs("avg_count", "avg_length", "last_visitor_session", "avg_star")
     def extract_cast(cls, ts: pd.Series, user_ids: pd.Series):

--- a/fennel/client_tests/test_invalid.py
+++ b/fennel/client_tests/test_invalid.py
@@ -73,7 +73,7 @@ class DomainFeatures:
     domain: str
     domain_used_count: int
 
-    @extractor(depends_on=[MemberActivityDatasetCopy])  # type: ignore
+    @extractor(deps=[MemberActivityDatasetCopy])  # type: ignore
     @inputs(Query.domain)
     @outputs("domain", "domain_used_count")
     def get_domain_feature(cls, ts: pd.Series, domain: pd.Series):
@@ -174,7 +174,7 @@ class TestInvalidExtractorDependsOn(unittest.TestCase):
             domain: str
             domain_used_count: int
 
-            @extractor(depends_on=[MemberActivityDatasetCopy])
+            @extractor(deps=[MemberActivityDatasetCopy])
             @inputs(Query.domain)
             @outputs("domain", "domain_used_count")
             def get_domain_feature(cls, ts: pd.Series, domain: pd.Series):

--- a/fennel/client_tests/test_movie_tickets.py
+++ b/fennel/client_tests/test_movie_tickets.py
@@ -153,7 +153,7 @@ class RequestFeatures:
 class ActorFeatures:
     revenue: int
 
-    @extractor(depends_on=[ActorStats], tier="prod")  # type: ignore
+    @extractor(deps=[ActorStats], tier="prod")  # type: ignore
     @inputs(RequestFeatures.name)
     @outputs("revenue")
     def extract_revenue(cls, ts: pd.Series, name: pd.Series):
@@ -161,7 +161,7 @@ class ActorFeatures:
         df = df.fillna(0)
         return df["revenue"]
 
-    @extractor(depends_on=[ActorStats], tier="staging")  # type: ignore
+    @extractor(deps=[ActorStats], tier="staging")  # type: ignore
     @inputs(RequestFeatures.name)
     @outputs("revenue")
     def extract_revenue2(cls, ts: pd.Series, name: pd.Series):

--- a/fennel/client_tests/test_outbrain.py
+++ b/fennel/client_tests/test_outbrain.py
@@ -81,7 +81,7 @@ class UserPageViewFeatures:
     page_views_3d: int
     page_views_9d: int
 
-    @extractor(depends_on=[PageViewsByUser], version=2)  # type: ignore
+    @extractor(deps=[PageViewsByUser], version=2)  # type: ignore
     @inputs(Request.uuid)
     @outputs("page_views", "page_views_1d", "page_views_3d", "page_views_9d")
     def extract(cls, ts: pd.Series, uuids: pd.Series):

--- a/fennel/client_tests/test_search.py
+++ b/fennel/client_tests/test_search.py
@@ -378,7 +378,7 @@ class UserBehaviorFeatures:
     num_short_views_7d: int
     num_long_views: int
 
-    @extractor(depends_on=[UserEngagementDataset])  # type: ignore
+    @extractor(deps=[UserEngagementDataset])  # type: ignore
     @inputs(Query.user_id)
     def get_user_features(cls, ts: pd.Series, user_id: pd.Series):
         df, _found = UserEngagementDataset.lookup(  # type: ignore
@@ -395,7 +395,7 @@ class DocumentFeatures:
     total_timespent_minutes: float
     num_views_28d: int
 
-    @extractor(depends_on=[DocumentEngagementDataset])  # type: ignore
+    @extractor(deps=[DocumentEngagementDataset])  # type: ignore
     @inputs(Query.doc_id)
     def get_doc_features(cls, ts: pd.Series, doc_id: pd.Series):
         df, found = DocumentEngagementDataset.lookup(  # type: ignore
@@ -415,7 +415,7 @@ class DocumentContentFeatures:
     num_stop_words: int
     top_10_unique_words: List[str]
 
-    @extractor(depends_on=[DocumentContentDatasetIndexed])  # type: ignore
+    @extractor(deps=[DocumentContentDatasetIndexed])  # type: ignore
     @inputs(Query.doc_id)
     def get_features(cls, ts: pd.Series, doc_id: pd.Series):
         df, found = DocumentContentDatasetIndexed.lookup(  # type: ignore
@@ -430,7 +430,7 @@ class TopWordsFeatures:
     word: str
     count: int
 
-    @extractor(depends_on=[TopWordsCount])  # type: ignore
+    @extractor(deps=[TopWordsCount])  # type: ignore
     @inputs("word")
     @outputs("count")
     def get_counts(cls, ts: pd.Series, word: pd.Series):

--- a/fennel/client_tests/test_session_window_operator.py
+++ b/fennel/client_tests/test_session_window_operator.py
@@ -135,7 +135,7 @@ class UserSessionStats:
     last_visitor_session: List[Window]
     avg_star: float
 
-    @extractor(depends_on=[SessionStats])  # type: ignore
+    @extractor(deps=[SessionStats])  # type: ignore
     @inputs("user_id")
     @outputs("avg_count", "avg_length", "last_visitor_session", "avg_star")
     def extract_cast(cls, ts: pd.Series, user_ids: pd.Series):

--- a/fennel/client_tests/test_social_network.py
+++ b/fennel/client_tests/test_social_network.py
@@ -161,7 +161,7 @@ class UserFeatures:
         LastViewedPostByAgg.post_id, default=[-1]  # type: ignore
     )
 
-    @extractor(depends_on=[UserViewsDataset])  # type: ignore
+    @extractor(deps=[UserViewsDataset])  # type: ignore
     @inputs(Request.user_id)
     @outputs("num_views")
     def extract_user_views(cls, ts: pd.Series, user_ids: pd.Series):
@@ -170,7 +170,7 @@ class UserFeatures:
 
         return views["num_views"]
 
-    @extractor(depends_on=[UserCategoryDataset, UserViewsDataset])  # type: ignore
+    @extractor(deps=[UserCategoryDataset, UserViewsDataset])  # type: ignore
     @inputs(Request.user_id, Request.category)
     @outputs("category_view_ratio", "num_category_views")
     def extractor_category_view(

--- a/fennel/client_tests/test_struct_type.py
+++ b/fennel/client_tests/test_struct_type.py
@@ -69,14 +69,14 @@ class MovieFeatures:
     cast_list: List[Cast]
     average_cast_age: float
 
-    @extractor(depends_on=[MovieInfo])  # type: ignore
+    @extractor(deps=[MovieInfo])  # type: ignore
     @inputs("movie")
     @outputs("cast_list")
     def extract_cast(cls, ts: pd.Series, movie: pd.Series):
         res, _ = MovieInfo.lookup(ts, movie=movie)  # type: ignore
         return pd.Series(res["cast_list"])
 
-    @extractor(depends_on=[MovieInfo])  # type: ignore
+    @extractor(deps=[MovieInfo])  # type: ignore
     @inputs("movie")
     @outputs("average_cast_age")
     def extract_average_cast_age(cls, ts: pd.Series, movie: pd.Series):

--- a/fennel/client_tests/test_tier_selector.py
+++ b/fennel/client_tests/test_tier_selector.py
@@ -108,7 +108,7 @@ class RequestFeatures:
 class ActorFeatures:
     revenue: int
 
-    @extractor(depends_on=[ActorStats], tier="prod")  # type: ignore
+    @extractor(deps=[ActorStats], tier="prod")  # type: ignore
     @inputs(RequestFeatures.name)
     @outputs("revenue")
     def extract_revenue(cls, ts: pd.Series, name: pd.Series):
@@ -116,7 +116,7 @@ class ActorFeatures:
         df = df.fillna(0)
         return df["revenue"]
 
-    @extractor(depends_on=[ActorStats], tier="staging")  # type: ignore
+    @extractor(deps=[ActorStats], tier="staging")  # type: ignore
     @inputs(RequestFeatures.name)
     @outputs("revenue")
     def extract_revenue2(cls, ts: pd.Series, name: pd.Series):

--- a/fennel/client_tests/test_tumbling_window_operator.py
+++ b/fennel/client_tests/test_tumbling_window_operator.py
@@ -135,7 +135,7 @@ class UserSessionStats:
     last_visitor_session: List[Window]
     avg_star: float
 
-    @extractor(depends_on=[SessionStats])  # type: ignore
+    @extractor(deps=[SessionStats])  # type: ignore
     @inputs("user_id")
     @outputs("avg_count", "avg_length", "last_visitor_session", "avg_star")
     def extract_cast(cls, ts: pd.Series, user_ids: pd.Series):
@@ -244,7 +244,7 @@ class UserSessionStatsHopping:
     last_visitor_session: List[Window]
     avg_star: float
 
-    @extractor(depends_on=[SessionStatsHopping])  # type: ignore
+    @extractor(deps=[SessionStatsHopping])  # type: ignore
     @inputs("user_id")
     @outputs("avg_count", "avg_length", "last_visitor_session", "avg_star")
     def extract_cast(cls, ts: pd.Series, user_ids: pd.Series):

--- a/fennel/datasets/test_dataset_lookup.py
+++ b/fennel/datasets/test_dataset_lookup.py
@@ -62,7 +62,7 @@ def test_dataset_lookup():
         age_cube: int = F().meta(owner="mohit@fennel.ai")
         gender: str
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs("userid", "name")
         @outputs("age_sq", "gender")
         @no_type_check
@@ -79,7 +79,7 @@ def test_dataset_lookup():
             df["age_sq"] = df["age"] * df["age"]
             return df[["age_sq", "gender"]]
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs("userid", "name")
         @outputs("age_cube")
         @no_type_check

--- a/fennel/datasets/test_invalid_indices.py
+++ b/fennel/datasets/test_invalid_indices.py
@@ -62,7 +62,7 @@ def test_invalid_dataset_lookup():
 
             @inputs("user_id")
             @outputs("age")
-            @extractor(depends_on=[Dataset1])
+            @extractor(deps=[Dataset1])
             def extract(cls, ts: pd.Series, user_ids: pd.Series):
                 data, _ = Dataset1.lookup(ts, user_id=user_ids)  # type: ignore
                 return data["age"].fillna(10)
@@ -81,7 +81,7 @@ def test_invalid_dataset_lookup():
 
             @inputs("user_id")
             @outputs("age")
-            @extractor(depends_on=[Dataset2])
+            @extractor(deps=[Dataset2])
             def extract(cls, ts: pd.Series, user_ids: pd.Series):
                 data, _ = Dataset2.lookup(ts, user_id=user_ids)  # type: ignore
                 return data["age"].fillna(10)
@@ -116,7 +116,7 @@ def test_invalid_dataset_online_lookup(client):
         user_id: int
         age: int
 
-        @extractor(depends_on=[Dataset1])
+        @extractor(deps=[Dataset1])
         @inputs("user_id")
         @outputs("age")
         def extract(cls, ts: pd.Series, user_ids: pd.Series):
@@ -173,7 +173,7 @@ def test_invalid_dataset_offline_lookup(client):
         user_id: int
         age: int
 
-        @extractor(depends_on=[Dataset1])
+        @extractor(deps=[Dataset1])
         @inputs("user_id")
         @outputs("age")
         def extract(cls, ts: pd.Series, user_ids: pd.Series):

--- a/fennel/featuresets/test_derived_extractors.py
+++ b/fennel/featuresets/test_derived_extractors.py
@@ -72,7 +72,7 @@ def test_valid_derived_extractors():
         # optional lookup derived feature
         optional_nickname: Optional[str] = F(UserInfoDataset.nickname)
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs("age_years")
         @outputs("age_group")
         def get_age_group(cls, ts: pd.Series, age: pd.Series):

--- a/fennel/featuresets/test_featureset.py
+++ b/fennel/featuresets/test_featureset.py
@@ -50,7 +50,7 @@ def test_simple_featureset():
         age: int = F().meta(owner="aditya@fennel.ai")
         income: int = F().meta(deprecated=True)
 
-        @extractor(depends_on=[UserInfoDataset], version=2)
+        @extractor(deps=[UserInfoDataset], version=2)
         @inputs(User.id, User.age)
         def get_user_info(
             cls, ts: pd.Series, user_id: pd.Series, user_age: pd.Series
@@ -185,13 +185,13 @@ def test_complex_featureset():
         age: int = F().meta(owner="aditya@fennel.ai")
         income: int
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs(User.id)
         @outputs("userid", "home_geoid")
         def get_user_info1(cls, ts: pd.Series, user_id: pd.Series):
             pass
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs(User.id)
         @outputs("gender", "age")
         def get_user_info2(cls, ts: pd.Series, user_id: pd.Series):
@@ -358,19 +358,19 @@ def test_extractor_tier_selector():
             tier=["~prod"],
         )
 
-        @extractor(depends_on=[UserInfoDataset], tier=["~prod", "~dev"])
+        @extractor(deps=[UserInfoDataset], tier=["~prod", "~dev"])
         @inputs(User.id)
         @outputs(user_id, "home_geoid")
         def get_user_info1(cls, ts: pd.Series, user_id: pd.Series):
             pass
 
-        @extractor(depends_on=[UserInfoDataset], tier=["prod"])
+        @extractor(deps=[UserInfoDataset], tier=["prod"])
         @inputs(User.id)
         @outputs(user_id, "home_geoid")
         def get_user_info2(cls, ts: pd.Series, user_id: pd.Series):
             pass
 
-        @extractor(depends_on=[UserInfoDataset], tier=["prod"])
+        @extractor(deps=[UserInfoDataset], tier=["prod"])
         @inputs(User.id)
         @outputs(income)
         def get_user_income(cls, ts: pd.Series, user_id: pd.Series):

--- a/fennel/featuresets/test_invalid_derived_extractors.py
+++ b/fennel/featuresets/test_invalid_derived_extractors.py
@@ -50,7 +50,7 @@ def test_invalid_multiple_extracts():
                 default=0,
             )
 
-            @extractor(depends_on=[UserInfoDataset])
+            @extractor(deps=[UserInfoDataset])
             @inputs(user_id)
             @outputs(age)
             def get_age(cls, ts: pd.Series, user_id: pd.Series):

--- a/fennel/featuresets/test_invalid_featureset.py
+++ b/fennel/featuresets/test_invalid_featureset.py
@@ -49,7 +49,7 @@ def test_featureset_as_input():
             userid: int
             home_geoid: int
 
-            @extractor(depends_on=[UserInfoDataset])
+            @extractor(deps=[UserInfoDataset])
             @inputs(User)
             @outputs("userid", "home_geoid")
             def get_user_info1(cls, ts: pd.Series, user: pd.Series):
@@ -74,13 +74,13 @@ def test_complex_featureset():
             age: int = F().meta(owner="aditya@fennel.ai")
             income: int
 
-            @extractor(depends_on=[UserInfoDataset])
+            @extractor(deps=[UserInfoDataset])
             @inputs(User.id)
             @outputs("userid", "home_geoid")
             def get_user_info1(cls, ts: pd.Series, user_id: pd.Series):
                 pass
 
-            @extractor(depends_on=[UserInfoDataset])
+            @extractor(deps=[UserInfoDataset])
             @inputs(User.id)
             @outputs("gender", "age")
             def get_user_info2(cls, ts: pd.Series, user_id: pd.Series):

--- a/fennel/internal_lib/to_proto/test_source_code.py
+++ b/fennel/internal_lib/to_proto/test_source_code.py
@@ -90,7 +90,7 @@ class UserFeature:
         ages = ts - dobs
         return pd.Series(ages)
 
-    @extractor(depends_on=[User])  # type: ignore
+    @extractor(deps=[User])  # type: ignore
     @inputs("uid")
     @outputs("country")
     def get_country(cls, ts: pd.Series, uids: pd.Series):
@@ -132,7 +132,7 @@ class UserInfoExtractor:
     age_cubed: int
     is_name_common: bool
 
-    @extractor(depends_on=[UserInfoDataset])  # type: ignore
+    @extractor(deps=[UserInfoDataset])  # type: ignore
     @includes(power_4, cube)
     @inputs("userid")
     @outputs("age", "age_power_four", "age_cubed", "is_name_common")

--- a/fennel/internal_lib/to_proto/test_to_proto.py
+++ b/fennel/internal_lib/to_proto/test_to_proto.py
@@ -49,7 +49,7 @@ class TestFeatureset:
     f2: int
     f3: int
 
-    @extractor(depends_on=[TestDataset])  # type: ignore
+    @extractor(deps=[TestDataset])  # type: ignore
     @includes(A, B, C)
     @outputs("f2", "f3")
     def test_extractor(cls, ts):
@@ -66,9 +66,9 @@ def rm_imports(pycode: pycode_proto.PyCode) -> pycode_proto.PyCode:
 def test_includes():
     f = {
         "entryPoint": "TestFeatureset_test_extractor",
-        "source_code": '@extractor(depends_on=[TestDataset])  # type: ignore\n@includes(A, B, C)\n@outputs("f2", "f3")\ndef test_extractor(cls, ts):\n    pass\n',
-        "core_code": '@extractor(depends_on=[TestDataset])  # type: ignore\n@includes(A, B, C)\n@outputs("f2", "f3")\ndef test_extractor(cls, ts):\n    pass\n',
-        "generated_code": '\n\n\n\n\ndef b1():\n    return 2\n\n\n\ndef a1():\n    return 1\n\n\n\n@includes(a1, b1)\ndef A():\n    return 11\n\n\n\ndef B():\n    return 22\n\n\n\ndef c1():\n    return 3\n\n\n\n@includes(c1)\ndef C():\n    return 33\n\n\n@index\n@dataset\nclass TestDataset:\n    a1: int = field(key=True)\n    t: datetime = field(timestamp=True)\n\n\n@featureset\nclass TestFeatureset:\n    f1: int\n    f2: int\n    f3: int\n\n    @extractor(depends_on=[TestDataset])  # type: ignore\n    @includes(A, B, C)\n    @outputs("f2", "f3")\n    def test_extractor(cls, ts):\n        pass\n\ndef TestFeatureset_test_extractor(*args, **kwargs):\n    x = TestFeatureset.__fennel_original_cls__\n    return getattr(x, "test_extractor")(*args, **kwargs)\n    ',
+        "source_code": '@extractor(deps=[TestDataset])  # type: ignore\n@includes(A, B, C)\n@outputs("f2", "f3")\ndef test_extractor(cls, ts):\n    pass\n',
+        "core_code": '@extractor(deps=[TestDataset])  # type: ignore\n@includes(A, B, C)\n@outputs("f2", "f3")\ndef test_extractor(cls, ts):\n    pass\n',
+        "generated_code": '\n\n\n\n\ndef b1():\n    return 2\n\n\n\ndef a1():\n    return 1\n\n\n\n@includes(a1, b1)\ndef A():\n    return 11\n\n\n\ndef B():\n    return 22\n\n\n\ndef c1():\n    return 3\n\n\n\n@includes(c1)\ndef C():\n    return 33\n\n\n@index\n@dataset\nclass TestDataset:\n    a1: int = field(key=True)\n    t: datetime = field(timestamp=True)\n\n\n@featureset\nclass TestFeatureset:\n    f1: int\n    f2: int\n    f3: int\n\n    @extractor(deps=[TestDataset])  # type: ignore\n    @includes(A, B, C)\n    @outputs("f2", "f3")\n    def test_extractor(cls, ts):\n        pass\n\ndef TestFeatureset_test_extractor(*args, **kwargs):\n    x = TestFeatureset.__fennel_original_cls__\n    return getattr(x, "test_extractor")(*args, **kwargs)\n    ',
         "includes": [
             {
                 "entryPoint": "A",

--- a/fennel/lib/includes/test_includes.py
+++ b/fennel/lib/includes/test_includes.py
@@ -54,7 +54,7 @@ class UserInfoSingleExtractor:
     age_cubed: int
     is_name_common: bool
 
-    @extractor(depends_on=[UserInfoDataset])  # type: ignore
+    @extractor(deps=[UserInfoDataset])  # type: ignore
     @includes(power_4, cube)
     @inputs("userid")
     @outputs(age, "age_power_four", "age_cubed", "is_name_common")

--- a/fennel/lib/includes/test_includes_invalid.py
+++ b/fennel/lib/includes/test_includes_invalid.py
@@ -48,7 +48,7 @@ class UserInfoExtractor:
     age_cubed: int
     is_name_common: bool
 
-    @extractor(depends_on=[UserInfoDataset])  # type: ignore
+    @extractor(deps=[UserInfoDataset])  # type: ignore
     @inputs("userid")
     @outputs(age, "age_power_four", "age_cubed", "is_name_common")
     def get_user_info(cls, ts: pd.Series, user_id: pd.Series):
@@ -124,7 +124,7 @@ def test_invalid_code_changes(client):
             age_cubed: int
             is_name_common: bool
 
-            @extractor(depends_on=[UserInfoDataset])
+            @extractor(deps=[UserInfoDataset])
             @includes(power_4, cube)
             @inputs(userid)
             @outputs(age, age_power_four, age_cubed, is_name_common)
@@ -163,7 +163,7 @@ def test_invalid_code_changes(client):
             age_cubed: int
             is_name_common: bool
 
-            @extractor(depends_on=[UserInfoDataset])
+            @extractor(deps=[UserInfoDataset])
             @includes(power_4_alt, cube)
             @inputs(userid)
             @outputs(age, age_power_four, age_cubed, is_name_common)
@@ -208,7 +208,7 @@ def test_invalid_code_changes(client):
             is_name_common: bool
             another_feature: int
 
-            @extractor(depends_on=[UserInfoDataset], version=1)
+            @extractor(deps=[UserInfoDataset], version=1)
             @includes(power_4, cube)
             @inputs(userid)
             @outputs(age, age_power_four, age_cubed, is_name_common)

--- a/fennel/lib/metadata/test_metadata.py
+++ b/fennel/lib/metadata/test_metadata.py
@@ -333,21 +333,21 @@ def test_featureset_with_extractors():
         age: int = F().meta(owner="aditya@fennel.ai")
         income: int
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @meta(owner="a@xyz.com", description="top_meta")
         @inputs(User.id)
         @outputs("userid", "home_geoid")
         def get_user_info1(cls, ts: pd.Series, user_id: pd.Series):
             pass
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs(User.id)
         @outputs("gender", "age")
         @meta(owner="b@xyz.com", description="middle_meta")
         def get_user_info2(cls, ts: pd.Series, user_id: pd.Series):
             pass
 
-        @extractor(depends_on=[UserInfoDataset])
+        @extractor(deps=[UserInfoDataset])
         @inputs(User.id)
         @outputs("income")
         @meta(owner="c@xyz.com", description="bottom_meta")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the naming convention from `depends_on` to `deps` in the `@extractor` decorator across various classes and functions to enhance clarity and consistency in specifying dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->