### PR TITLE
[DEV 3874] Added capability to use kwargs in groupby.aggregate

### DIFF
--- a/docs/examples/api-reference/aggregations/avg.py
+++ b/docs/examples/api-reference/aggregations/avg.py
@@ -45,12 +45,8 @@ def test_basic(client):
         def avg_pipeline(cls, ds: Dataset):
             return ds.groupby("uid").aggregate(
                 # docsnip-highlight start
-                Average(
-                    of="amt", window="1d", default=-1.0, into_field="avg_1d"
-                ),
-                Average(
-                    of="amt", window="1w", default=-1.0, into_field="avg_1w"
-                ),
+                avg_1d=Average(of="amt", window="1d", default=-1.0),
+                avg_1w=Average(of="amt", window="1w", default=-1.0),
                 # docsnip-highlight end
             )
 
@@ -146,12 +142,7 @@ def test_invalid_type(client):
             def invalid_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Average(
-                        of="zip",
-                        window="1d",
-                        default="avg",
-                        into_field="avg_1d",
-                    ),
+                    avg_1d=Average(of="zip", window="1d", default="avg"),
                     # docsnip-highlight end
                 )
 
@@ -189,9 +180,7 @@ def test_non_matching_types(client):
             def invalid_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Average(
-                        of="amt", window="1d", default=1.0, into_field="ret"
-                    ),
+                    ret=Average(of="amt", window="1d", default=1.0),
                     # docsnip-highlight end
                 )
 

--- a/docs/examples/api-reference/aggregations/count.py
+++ b/docs/examples/api-reference/aggregations/count.py
@@ -48,13 +48,12 @@ class TestCountSnips(unittest.TestCase):
             def count_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Count(window="forever", into_field="num_transactions"),
-                    Count(
+                    num_transactions=Count(window="forever"),
+                    unique_vendors_1w=Count(
                         of="vendor",
                         unique=True,
                         approx=True,
                         window="1w",
-                        into_field="unique_vendors_1w",
                     ),
                     # docsnip-highlight end
                 )

--- a/docs/examples/api-reference/aggregations/distinct.py
+++ b/docs/examples/api-reference/aggregations/distinct.py
@@ -45,10 +45,9 @@ def test_basic(client):
         def distinct_pipeline(cls, ds: Dataset):
             return ds.groupby("uid").aggregate(
                 # docsnip-highlight start
-                Distinct(
+                amounts=Distinct(
                     of="amount",
                     window="1d",
-                    into_field="amounts",
                     unordered=True,
                 ),
                 # docsnip-highlight end
@@ -145,10 +144,9 @@ def test_invalid_type(client):
             def bad_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Distinct(
+                    amounts=Distinct(
                         of="amount",
                         limit=10,
-                        into_field="amounts",
                         unordered=True,
                     ),
                     # docsnip-highlight end

--- a/docs/examples/api-reference/aggregations/lastk.py
+++ b/docs/examples/api-reference/aggregations/lastk.py
@@ -37,12 +37,11 @@ def test_basic(client):
         def lastk_pipeline(cls, ds: Dataset):
             return ds.groupby("uid").aggregate(
                 # docsnip-highlight start
-                LastK(
+                amounts=LastK(
                     of="amount",
                     limit=10,
                     dedup=False,
                     window="1d",
-                    into_field="amounts",
                 ),
                 # docsnip-highlight end
             )
@@ -138,12 +137,11 @@ def test_invalid_type(client):
             def bad_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    LastK(
+                    amounts=LastK(
                         of="amount",
                         limit=10,
                         dedup=False,
                         window="1d",
-                        into_field="amounts",
                     ),
                     # docsnip-highlight end
                 )

--- a/docs/examples/api-reference/aggregations/max.py
+++ b/docs/examples/api-reference/aggregations/max.py
@@ -39,8 +39,8 @@ def test_basic(client):
         def def_pipeline(cls, ds: Dataset):
             return ds.groupby("uid").aggregate(
                 # docsnip-highlight start
-                Max(of="amt", window="1d", default=-1.0, into_field="max_1d"),
-                Max(of="amt", window="1w", default=-1.0, into_field="max_1w"),
+                max_1d=Max(of="amt", window="1d", default=-1.0),
+                max_1w=Max(of="amt", window="1w", default=-1.0),
                 # docsnip-highlight end
             )
 
@@ -136,7 +136,7 @@ def test_invalid_type(client):
             def def_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight next-line
-                    Max(of="zip", window="1d", default="max", into_field="max"),
+                    max=Max(of="zip", window="1d", default="max"),
                 )
 
         # /docsnip
@@ -172,7 +172,7 @@ def test_non_matching_types(client):
             def def_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight next-line
-                    Max(of="amt", window="1d", default=1, into_field="max_1d"),
+                    max_1d=Max(of="amt", window="1d", default=1),
                 )
 
         # /docsnip

--- a/docs/examples/api-reference/aggregations/min.py
+++ b/docs/examples/api-reference/aggregations/min.py
@@ -38,8 +38,8 @@ def test_basic(client):
         def min_pipeline(cls, ds: Dataset):
             return ds.groupby("uid").aggregate(
                 # docsnip-highlight start
-                Min(of="amt", window="1d", default=-1.0, into_field="min_1d"),
-                Min(of="amt", window="1w", default=-1.0, into_field="min_1w"),
+                min_1d=Min(of="amt", window="1d", default=-1.0),
+                min_1w=Min(of="amt", window="1w", default=-1.0),
                 # docsnip-highlight end
             )
 
@@ -135,7 +135,7 @@ def test_invalid_type(client):
             def invalid_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Min(of="zip", window="1d", default="min", into_field="min"),
+                    min=Min(of="zip", window="1d", default="min"),
                     # docsnip-highlight end
                 )
 
@@ -172,7 +172,7 @@ def test_non_matching_types(client):
             def invalid_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Min(of="amt", window="1d", default=1, into_field="min_1d"),
+                    min_1d=Min(of="amt", window="1d", default=1),
                     # docsnip-highlight end
                 )
 

--- a/docs/examples/api-reference/aggregations/quantile.py
+++ b/docs/examples/api-reference/aggregations/quantile.py
@@ -48,10 +48,9 @@ class TestQuantileSnips(unittest.TestCase):
             def quantil_pipeline(cls, ds: Dataset):
                 # docsnip-highlight start
                 return ds.groupby("uid").aggregate(
-                    Quantile(
+                    median_amount_1w=Quantile(
                         of="amount",
                         window="1w",
-                        into_field="median_amount_1w",
                         p=0.5,
                         approx=True,
                         default=0.0,
@@ -151,10 +150,9 @@ class TestQuantileSnips(unittest.TestCase):
                 @inputs(Transaction)
                 def bad_pipeline(cls, ds: Dataset):
                     return ds.groupby("uid").aggregate(
-                        Quantile(
+                        median_amount_1w=Quantile(
                             of="amount",
                             window="1w",
-                            into_field="median_amount_1w",
                             p=0.5,
                             approx=True,
                             default=0.0,
@@ -194,10 +192,9 @@ class TestQuantileSnips(unittest.TestCase):
                 @inputs(Transaction)
                 def bad_pipeline(cls, ds: Dataset):
                     return ds.groupby("uid").aggregate(
-                        Quantile(
+                        median_amount_1w=Quantile(
                             of="amount",
                             window="1w",
-                            into_field="median_amount_1w",
                             p=0.5,
                             approx=True,
                         ),
@@ -237,10 +234,9 @@ class TestQuantileSnips(unittest.TestCase):
                 @inputs(Transaction)
                 def bad_pipeline(cls, ds: Dataset):
                     return ds.groupby("uid").aggregate(
-                        Quantile(
+                        median_amount_1w=Quantile(
                             of="amount",
                             window="1w",
-                            into_field="median_amount_1w",
                             # docsnip-highlight next-line
                             p=10.0,
                             approx=True,

--- a/docs/examples/api-reference/aggregations/stddev.py
+++ b/docs/examples/api-reference/aggregations/stddev.py
@@ -44,11 +44,9 @@ def test_basic(client):
         @inputs(Transaction)
         def stddev_pipeline(cls, ds: Dataset):
             return ds.groupby("uid").aggregate(
-                Average(of="amt", window="1d", default=-1.0, into_field="mean"),
+                mean=Average(of="amt", window="1d", default=-1.0),
                 # docsnip-highlight start
-                Stddev(
-                    of="amt", window="1d", default=-1.0, into_field="stddev"
-                ),
+                stddev=Stddev(of="amt", window="1d", default=-1.0),
                 # docsnip-highlight end
             )
 
@@ -151,9 +149,7 @@ def test_invalid_type(client):
             def invalid_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Stddev(
-                        of="zip", window="1d", default="x", into_field="var"
-                    ),
+                    var=Stddev(of="zip", window="1d", default="x"),
                     # docsnip-highlight end
                 )
 
@@ -196,9 +192,7 @@ def test_non_matching_types(client):
             def invalid_pipeline(cls, ds: Dataset):
                 return ds.groupby("uid").aggregate(
                     # docsnip-highlight start
-                    Stddev(
-                        of="amt", window="1d", default=1.0, into_field="ret"
-                    ),
+                    ret=Stddev(of="amt", window="1d", default=1.0),
                     # docsnip-highlight end
                 )
 

--- a/docs/examples/api-reference/aggregations/sum.py
+++ b/docs/examples/api-reference/aggregations/sum.py
@@ -48,8 +48,8 @@ class TestSumSnips(unittest.TestCase):
             def sum_pipeline(cls, ds: Dataset):
                 # docsnip-highlight start
                 return ds.groupby("uid").aggregate(
-                    Sum(of="amount", window="1w", into_field="amount_1w"),
-                    Sum(of="amount", window="forever", into_field="total"),
+                    amount_1w=Sum(of="amount", window="1w"),
+                    total=Sum(of="amount", window="forever"),
                 )
                 # docsnip-highlight end
 
@@ -147,7 +147,7 @@ class TestSumSnips(unittest.TestCase):
                 def bad_pipeline(cls, ds: Dataset):
                     return ds.groupby("uid").aggregate(
                         # docsnip-highlight next-line
-                        Sum(of="vendor", window="forever", into_field="total"),
+                        total=Sum(of="vendor", window="forever"),
                     )
 
             # /docsnip

--- a/docs/examples/api-reference/operators/aggregate.py
+++ b/docs/examples/api-reference/operators/aggregate.py
@@ -49,8 +49,8 @@ class TestAssignSnips(unittest.TestCase):
             def aggregate_pipeline(cls, ds: Dataset):
                 # docsnip-highlight start
                 return ds.groupby("uid").aggregate(
-                    Count(window="1d", into_field="count_1d"),
-                    Sum(of="amount", window="forever", into_field="total"),
+                    count_1d=Count(window="1d"),
+                    total=Sum(of="amount", window="forever"),
                 )
                 # docsnip-highlight end
 

--- a/docs/examples/api-reference/operators_ref.py
+++ b/docs/examples/api-reference/operators_ref.py
@@ -154,8 +154,8 @@ class FraudActivityDataset:
 
         # docsnip aggregate
         aggregated_ds = joined_ds.groupby("merchant_category").aggregate(
-            Sum(of="txn_amount", window="1h", into_field="txn_sum"),
-            Count(window="1h", into_field="txn_count"),
+            txn_sum=Sum(of="txn_amount", window="1h"),
+            txn_count=Count(window="1h"),
         )
         # /docsnip
         return aggregated_ds

--- a/docs/examples/concepts/introduction.py
+++ b/docs/examples/concepts/introduction.py
@@ -81,9 +81,9 @@ def test_overview(client):
                 lambda df: df["country"] != df["payment_country"]
             )
             return abroad.groupby("uid").aggregate(
-                Count(window="forever", into_field="count"),
-                Sum(of="amount", window="1d", into_field="amount_1d"),
-                Sum(of="amount", window="1w", into_field="amount_1w"),
+                count=Count(window="forever"),
+                amount_1d=Sum(of="amount", window="1d"),
+                amount_1w=Sum(of="amount", window="1w"),
             )
 
         # docsnip-highlight end

--- a/docs/examples/datasets/pipelines.py
+++ b/docs/examples/datasets/pipelines.py
@@ -63,9 +63,9 @@ def test_pipeline_basic():
                 lambda df: df["country"] != df["payment_country"]
             )
             return abroad.groupby("uid").aggregate(
-                Count(window="forever", into_field="count"),
-                Sum(of="amount", window="1d", into_field="amount_1d"),
-                Sum(of="amount", window="1w", into_field="amount_1w"),
+                count=Count(window="forever"),
+                amount_1d=Sum(of="amount", window="1d"),
+                amount_1w=Sum(of="amount", window="1w"),
             )
 
         # docsnip-highlight end
@@ -277,7 +277,7 @@ def test_multiple_pipelines(client):
             )
             union = with_ios_platform + with_android_platform
             return union.groupby(["uid", "platform"]).aggregate(
-                Count(window="1d", into_field="num_logins_1d"),
+                num_logins_1d=Count(window="1d"),
             )
 
     # /docsnip

--- a/docs/examples/examples/ecommerce.py
+++ b/docs/examples/examples/ecommerce.py
@@ -63,8 +63,8 @@ class UserSellerOrders:
     @inputs(Order)
     def my_pipeline(cls, orders: Dataset):
         return orders.groupby("uid", "seller_id").aggregate(
-            Count(window="1d", into_field="num_orders_1d"),
-            Count(window="1w", into_field="num_orders_1w"),
+            num_orders_1d=Count(window="1d"),
+            num_orders_1w=Count(window="1w"),
         )
 
 

--- a/docs/examples/getting-started/quickstart.py
+++ b/docs/examples/getting-started/quickstart.py
@@ -95,8 +95,8 @@ class UserSellerOrders:
         orders = orders.drop("product_id", "desc", "price")
         orders = orders.dropnull()
         return orders.groupby("uid", "seller_id").aggregate(
-            Count(window="1d", into_field="num_orders_1d"),
-            Count(window="1w", into_field="num_orders_1w"),
+            num_orders_1d=Count(window="1d"),
+            num_orders_1w=Count(window="1w"),
         )
 
 

--- a/docs/examples/testing-and-ci-cd/unit_tests.py
+++ b/docs/examples/testing-and-ci-cd/unit_tests.py
@@ -36,9 +36,9 @@ class MovieRating:
     @inputs(RatingActivity)
     def pipeline_aggregate(cls, activity: Dataset):
         return activity.groupby("movie").aggregate(
-            Count(window="7d", into_field="num_ratings"),
-            Sum(window="28d", of="rating", into_field="sum_ratings"),
-            Average(window="12h", of="rating", into_field="rating"),
+            num_ratings=Count(window="7d"),
+            sum_ratings=Sum(window="28d", of="rating"),
+            rating=Average(window="12h", of="rating"),
         )
 
 

--- a/fennel/datasets/aggregate.py
+++ b/fennel/datasets/aggregate.py
@@ -10,7 +10,7 @@ ItemType = Union[str, List[str]]
 class AggregateType(BaseModel):
     window: Last
     # Name of the field the aggregate will  be assigned to
-    into_field: str
+    into_field: str = ""
 
     @validator("window", pre=True)
     # Converting the window into Last object

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -498,7 +498,7 @@ class GroupBy:
     def aggregate(self, *args, **kwargs) -> _Node:
         if len(args) == 0 and len(kwargs) == 0:
             raise TypeError(
-                "aggregate operator expects atleast one aggregation operation"
+                "aggregate operator expects at least one aggregation operation"
             )
         if len(args) == 1 and isinstance(args[0], list):
             aggregates = args[0]
@@ -518,7 +518,8 @@ class GroupBy:
         for aggregate in aggregates:
             if aggregate.into_field == "":
                 raise ValueError(
-                    "Please specify the name of the output field for aggregate either through param 'into_field' or via named params"
+                    "Specify the output field name for the aggregate using 'into_field' "
+                    "parameter or through named arguments."
                 )
 
         return Aggregate(self.node, list(self.keys), aggregates)


### PR DESCRIPTION
Support aggregate something like:

return txns_amt_spent.groupby("user_id").aggregate(
           amt_spent_7d=Sum(window="7d", of="amount_spent"),
           median_amt_spent_7d=Quantile(window="7d", of="amount_spent", approx=True, default=0, p=0.5),
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Streamlined aggregation logic across multiple examples and datasets for enhanced readability and maintainability.
- **Documentation**
	- Updated examples and API references to demonstrate the use of named arguments and direct field assignments in aggregation functions.
- **New Features**
	- Enhanced the flexibility of the aggregation method by accepting both keyword and positional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->