### PR TITLE
[DEV 3882] Removed warnings

### DIFF
--- a/docs/examples/api-reference/client.py
+++ b/docs/examples/api-reference/client.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -90,7 +90,7 @@ class TestExtractorDAGResolution(unittest.TestCase):
         )
         # /docsnip
         # docsnip log_api
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "John", 32, "USA", now],
             [18234, "Monica", 24, "Chile", now],

--- a/docs/examples/api-reference/client/log.py
+++ b/docs/examples/api-reference/client/log.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -41,7 +41,10 @@ def test_basic(client):
     # docsnip-highlight end
     # /docsnip
     # do lookup to verify that the rows were logged
-    ts = [datetime(2021, 1, 1, 0, 0, 0), datetime(2021, 2, 1, 0, 0, 0)]
+    ts = [
+        datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        datetime(2021, 2, 1, 0, 0, 0, tzinfo=timezone.utc),
+    ]
     df, found = Transaction.lookup(pd.Series(ts), uid=pd.Series([1, 2]))
     assert found.tolist() == [True, True]
     assert df["uid"].tolist() == [1, 2]

--- a/docs/examples/api-reference/client/query.py
+++ b/docs/examples/api-reference/client/query.py
@@ -1,9 +1,9 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from datetime import timedelta
 
+import pandas as pd
 import pytest
 
-import pandas as pd
 from fennel.testing import mock
 
 HOUR = timedelta(hours=1)
@@ -61,7 +61,11 @@ def test_basic(client):
             format="pandas",
             input_dataframe=pd.DataFrame(
                 {"Numbers.num": [1, 2, 3, 4]},
-                {"timestamp": [datetime.utcnow() - HOUR * i for i in range(4)]},
+                {
+                    "timestamp": [
+                        datetime.now(timezone.utc) - HOUR * i for i in range(4)
+                    ]
+                },
             ),
             timestamp_column="timestamp",
         )

--- a/docs/examples/api-reference/data-types.py
+++ b/docs/examples/api-reference/data-types.py
@@ -40,7 +40,7 @@ def test_func():
 def test_restrictions(client):
     # docsnip dataset_type_restrictions
     # imports for data types
-    from datetime import datetime
+    from datetime import datetime, timezone
     from fennel.dtypes import oneof, between, regex
 
     # imports for datasets
@@ -64,7 +64,7 @@ def test_restrictions(client):
     # /docsnip
 
     client.commit(message="msg", datasets=[UserInfoDataset])
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 123,

--- a/docs/examples/api-reference/operators/assign.py
+++ b/docs/examples/api-reference/operators/assign.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -56,7 +56,9 @@ class TestAssignSnips(unittest.TestCase):
         assert df["uid"].tolist() == [1]
         assert df["amount"].tolist() == [10]
         assert df["amount_sq"].tolist() == [100]
-        assert df["timestamp"].tolist() == [datetime(2021, 1, 1, 0, 0, 0)]
+        assert df["timestamp"].tolist() == [
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        ]
         assert found.tolist() == [True]
 
     @mock

--- a/docs/examples/api-reference/operators/dedup.py
+++ b/docs/examples/api-reference/operators/dedup.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 from fennel.testing import mock
@@ -74,8 +74,8 @@ class TestDedupSnips(unittest.TestCase):
         assert df["uid"].tolist() == [1, 2]
         assert df["amount"].tolist() == [10, 20]
         assert df["timestamp"].tolist() == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 2, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
         ]
 
     @mock
@@ -144,6 +144,6 @@ class TestDedupSnips(unittest.TestCase):
         assert df["uid"].tolist() == [1, 2]
         assert df["amount"].tolist() == [10, 20]
         assert df["timestamp"].tolist() == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 2, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
         ]

--- a/docs/examples/api-reference/operators/drop.py
+++ b/docs/examples/api-reference/operators/drop.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -100,8 +100,8 @@ class TestFilterSnips(unittest.TestCase):
         assert df["uid"].tolist() == [1, 2, 3]
         assert df["gender"].tolist() == ["M", "F", "M"]
         assert df["timestamp"].tolist()[1:] == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]
 
     @mock

--- a/docs/examples/api-reference/operators/dropnull.py
+++ b/docs/examples/api-reference/operators/dropnull.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -94,7 +94,9 @@ class TestDropnullSnips(unittest.TestCase):
         assert df["uid"].tolist()[0] == 1
         assert df["dob"].tolist()[0] == "1990-01-01"
         assert df["gender"].tolist()[0] == "M"
-        assert df["timestamp"].tolist()[0] == datetime(2021, 1, 1, 0, 0, 0)
+        assert df["timestamp"].tolist()[0] == datetime(
+            2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
 
     @mock
     def test_dropnull_all(self, client):
@@ -179,7 +181,9 @@ class TestDropnullSnips(unittest.TestCase):
         assert df["uid"].tolist()[0] == 1
         assert df["dob"].tolist()[0] == "1990-01-01"
         assert df["gender"].tolist()[0] == "M"
-        assert df["timestamp"].tolist()[0] == datetime(2021, 1, 1, 0, 0, 0)
+        assert df["timestamp"].tolist()[0] == datetime(
+            2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
 
     @mock
     def test_missing_column(self, client):

--- a/docs/examples/api-reference/operators/explode.py
+++ b/docs/examples/api-reference/operators/explode.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from typing import List, Optional
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -82,9 +82,9 @@ class TestExplodeSnips(unittest.TestCase):
         assert df["sku"].tolist() == [1, 2, None]
         assert df["price"].tolist() == [10.1, 20.0, None]
         assert df["timestamp"].tolist() == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]
 
     @mock

--- a/docs/examples/api-reference/operators/filter.py
+++ b/docs/examples/api-reference/operators/filter.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -77,8 +77,8 @@ class TestFilterSnips(unittest.TestCase):
         assert df["uid"].tolist()[1:] == [2, 3]
         assert df["city"].tolist()[1:] == ["San Francisco", "New York"]
         assert df["signup_time"].tolist()[1:] == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]
 
     @mock

--- a/docs/examples/api-reference/operators/groupby.py
+++ b/docs/examples/api-reference/operators/groupby.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -76,8 +76,8 @@ class TestGroupbySnips(unittest.TestCase):
         assert df["category"].tolist() == ["grocery", "electronics"]
         assert df["uid"].tolist() == [1, 2]
         assert df["timestamp"].tolist() == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 2, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 2, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]
 
     @mock

--- a/docs/examples/api-reference/operators/join.py
+++ b/docs/examples/api-reference/operators/join.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -114,4 +114,7 @@ class TestAssignSnips(unittest.TestCase):
         assert df["merchant"].tolist() == [4, 5, 4]
         assert df["amount"].tolist() == [10, 20, 30]
         assert df["category"].tolist() == ["grocery", "electronics", "grocery"]
-        assert df["timestamp"].tolist() == [datetime(2021, 1, 1, 0, 0, 0)] * 3
+        assert (
+            df["timestamp"].tolist()
+            == [datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)] * 3
+        )

--- a/docs/examples/api-reference/operators/rename.py
+++ b/docs/examples/api-reference/operators/rename.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -92,6 +92,6 @@ class TestRenameSnips(unittest.TestCase):
         assert df["weight_lb"].tolist() == [150, 140, 160]
         assert df["height_in"].tolist() == [63, 60, 58]
         assert df["timestamp"].tolist()[1:] == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]

--- a/docs/examples/api-reference/operators/select.py
+++ b/docs/examples/api-reference/operators/select.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -97,8 +97,8 @@ class TestSelectSnips(unittest.TestCase):
         assert df["weight"].tolist() == [150, 140, 160]
         assert df["height"].tolist() == [63, 60, 58]
         assert df["timestamp"].tolist()[1:] == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]
 
     @mock

--- a/docs/examples/api-reference/operators/summarize.py
+++ b/docs/examples/api-reference/operators/summarize.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -97,15 +97,37 @@ class TestSummarizeSnips(unittest.TestCase):
             window=pd.Series(
                 [
                     {
-                        "begin": pd.Timestamp(datetime(2021, 1, 1, 0, 0, 0)),
+                        "begin": pd.Timestamp(
+                            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+                        ),
                         "end": pd.Timestamp(
-                            datetime(2021, 1, 1, 0, 10, 0, microsecond=1)
+                            datetime(
+                                2021,
+                                1,
+                                1,
+                                0,
+                                10,
+                                0,
+                                microsecond=1,
+                                tzinfo=timezone.utc,
+                            )
                         ),
                     },
                     {
-                        "begin": pd.Timestamp(datetime(2021, 1, 2, 0, 10, 0)),
+                        "begin": pd.Timestamp(
+                            datetime(2021, 1, 2, 0, 10, 0, tzinfo=timezone.utc)
+                        ),
                         "end": pd.Timestamp(
-                            datetime(2021, 1, 2, 0, 15, 0, microsecond=1)
+                            datetime(
+                                2021,
+                                1,
+                                2,
+                                0,
+                                15,
+                                0,
+                                microsecond=1,
+                                tzinfo=timezone.utc,
+                            )
                         ),
                     },
                 ]
@@ -248,18 +270,40 @@ class TestSummarizeSnips(unittest.TestCase):
                     [
                         {
                             "begin": pd.Timestamp(
-                                datetime(2021, 1, 1, 0, 0, 0)
+                                datetime(
+                                    2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+                                )
                             ),
                             "end": pd.Timestamp(
-                                datetime(2021, 1, 1, 0, 10, 0, microsecond=1)
+                                datetime(
+                                    2021,
+                                    1,
+                                    1,
+                                    0,
+                                    10,
+                                    0,
+                                    microsecond=1,
+                                    tzinfo=timezone.utc,
+                                )
                             ),
                         },
                         {
                             "begin": pd.Timestamp(
-                                datetime(2021, 1, 2, 0, 10, 0)
+                                datetime(
+                                    2021, 1, 2, 0, 10, 0, tzinfo=timezone.utc
+                                )
                             ),
                             "end": pd.Timestamp(
-                                datetime(2021, 1, 2, 0, 15, 0, microsecond=1)
+                                datetime(
+                                    2021,
+                                    1,
+                                    2,
+                                    0,
+                                    15,
+                                    0,
+                                    microsecond=1,
+                                    tzinfo=timezone.utc,
+                                )
                             ),
                         },
                     ]

--- a/docs/examples/api-reference/operators/transform.py
+++ b/docs/examples/api-reference/operators/transform.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -63,7 +63,9 @@ class TestAssignSnips(unittest.TestCase):
         assert df["uid"].tolist() == [1]
         assert df["amount"].tolist() == [10]
         assert df["amount_sq"].tolist() == [100]
-        assert df["timestamp"].tolist() == [datetime(2021, 1, 1, 0, 0, 0)]
+        assert df["timestamp"].tolist() == [
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        ]
         assert found.tolist() == [True]
 
     @mock

--- a/docs/examples/api-reference/operators/window.py
+++ b/docs/examples/api-reference/operators/window.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -90,15 +90,37 @@ class TestAssignSnips(unittest.TestCase):
             window=pd.Series(
                 [
                     {
-                        "begin": pd.Timestamp(datetime(2021, 1, 1, 0, 0, 0)),
+                        "begin": pd.Timestamp(
+                            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+                        ),
                         "end": pd.Timestamp(
-                            datetime(2021, 1, 1, 0, 10, 0, microsecond=1)
+                            datetime(
+                                2021,
+                                1,
+                                1,
+                                0,
+                                10,
+                                0,
+                                microsecond=1,
+                                tzinfo=timezone.utc,
+                            )
                         ),
                     },
                     {
-                        "begin": pd.Timestamp(datetime(2021, 1, 2, 0, 10, 0)),
+                        "begin": pd.Timestamp(
+                            datetime(2021, 1, 2, 0, 10, 0, tzinfo=timezone.utc)
+                        ),
                         "end": pd.Timestamp(
-                            datetime(2021, 1, 2, 0, 15, 0, microsecond=1)
+                            datetime(
+                                2021,
+                                1,
+                                2,
+                                0,
+                                15,
+                                0,
+                                microsecond=1,
+                                tzinfo=timezone.utc,
+                            )
                         ),
                     },
                 ]

--- a/docs/examples/api-reference/sources/webhook.py
+++ b/docs/examples/api-reference/sources/webhook.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-from unittest.mock import patch
 import os
+from datetime import datetime, timezone
+from unittest.mock import patch
+
 import pandas as pd
 
 from fennel.testing import mock
@@ -41,9 +42,9 @@ def test_webhook_basic(client):
             "uid": [1, 2, 3],
             "email": ["a@gmail.com", "b@gmail.com", "c@gmail.com"],
             "timestamp": [
-                datetime.utcnow(),
-                datetime.utcnow(),
-                datetime.utcnow(),
+                datetime.now(timezone.utc),
+                datetime.now(timezone.utc),
+                datetime.now(timezone.utc),
             ],
         }
     )

--- a/docs/examples/concepts/introduction.py
+++ b/docs/examples/concepts/introduction.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -148,7 +148,7 @@ def test_overview(client):
         tier="local",
     )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     dob = now - timedelta(days=365 * 30)
     data = [
         [1, dob, "US", now - timedelta(days=1)],
@@ -225,8 +225,8 @@ def test_overview(client):
             {
                 "UserFeature.uid": [1, 3],
                 "timestamp": [
-                    datetime.utcnow(),
-                    datetime.utcnow() - timedelta(days=1),
+                    datetime.now(timezone.utc),
+                    datetime.now(timezone.utc) - timedelta(days=1),
                 ],
             }
         ),

--- a/docs/examples/datasets/lookups.py
+++ b/docs/examples/datasets/lookups.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 
@@ -46,7 +46,7 @@ class UserFeature:
 @mock
 def test_user_dataset_lookup(client):
     client.commit(message="msg", datasets=[User], featuresets=[UserFeature])
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     data = [
         [1, "San Francisco", "New York", now - timedelta(days=1)],

--- a/docs/examples/datasets/pipelines.py
+++ b/docs/examples/datasets/pipelines.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import requests
@@ -80,7 +80,7 @@ def test_transaction_aggregation_example(client):
     client.commit(
         message="msg", datasets=[User, Transaction, UserTransactionsAbroad]
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     dob = now - timedelta(days=365 * 30)
     data = [
         [1, dob, "US", now - timedelta(days=1)],
@@ -170,7 +170,7 @@ def test_fraud(client):
     # /docsnip
     # # Sync the dataset
     client.commit(message="msg", datasets=[Activity, FraudActivity])
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     minute_ago = now - timedelta(minutes=1)
     data = [
         [
@@ -281,7 +281,7 @@ def test_multiple_pipelines(client):
     client.commit(
         message="msg", datasets=[AndroidLogins, IOSLogins, LoginStats]
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         [1, now],
         [1, now - timedelta(days=1)],

--- a/docs/examples/examples/ecommerce.py
+++ b/docs/examples/examples/ecommerce.py
@@ -1,6 +1,6 @@
 # docsnip imports
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import requests
@@ -107,7 +107,7 @@ class TestUserLivestreamFeatures(unittest.TestCase):
             tier="dev",
         )
         columns = ["uid", "product_id", "seller_id", "timestamp"]
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [1, 1, 1, now - timedelta(days=8)],
             [1, 2, 1, now - timedelta(days=6)],

--- a/docs/examples/featuresets/overview.py
+++ b/docs/examples/featuresets/overview.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -436,7 +436,7 @@ def test_multiple_features_extracted(client):
         datasets=[UserInfo],
         featuresets=[UserLocationFeatures],
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [[1, "New York", now], [2, "London", now], [3, "Paris", now]]
     df = pd.DataFrame(data, columns=["uid", "city", "update_time"])
     res = client.log("fennel_webhook", "UserInfo", df)
@@ -514,7 +514,7 @@ def test_extractors_across_featuresets(client):
         datasets=[UserInfo],
         featuresets=[Request, UserLocationFeaturesRefactored],
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [[1, "New York", now], [2, "London", now], [3, "Paris", now]]
     df = pd.DataFrame(data, columns=["uid", "city", "update_time"])
     res = client.log("fennel_webhook", "UserInfo", df)

--- a/docs/examples/featuresets/reading_datasets.py
+++ b/docs/examples/featuresets/reading_datasets.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-
+from datetime import datetime, timezone
 import pandas as pd
 
 from fennel.testing import mock
@@ -81,7 +80,7 @@ def test_lookup_in_extractor(client):
         datasets=[User],
         featuresets=[UserFeatures, UserFeaturesDerived, UserFeaturesDerived2],
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = pd.DataFrame(
         {
             "uid": [1, 2, 3],

--- a/docs/examples/getting-started/quickstart.py
+++ b/docs/examples/getting-started/quickstart.py
@@ -1,5 +1,5 @@
 # docsnip imports
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import pandas as pd
@@ -137,7 +137,7 @@ client.commit(
 
 # docsnip log_data
 # create some product data
-now = datetime.utcnow()
+now = datetime.now(timezone.utc)
 columns = ["product_id", "seller_id", "price", "desc", "last_modified"]
 data = [
     [1, 1, 10.0, "product 1", now],

--- a/docs/examples/testing-and-ci-cd/unit_tests.py
+++ b/docs/examples/testing-and-ci-cd/unit_tests.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import pandas as pd
@@ -58,7 +58,7 @@ class TestDataset(unittest.TestCase):
             message="datasets: add RatingActivity and MovieRating",
             datasets=[MovieRating, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         two_hours_ago = now - timedelta(hours=2)
         three_hours_ago = now - timedelta(hours=3)
@@ -225,7 +225,7 @@ class TestExtractorDAGResolution(unittest.TestCase):
             datasets=[UserInfoDataset],
             featuresets=[UserInfoMultipleExtractor],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "John", 32, "USA", now],
             [18234, "Monica", 24, "Chile", now],

--- a/docs/examples/useful-tips/debugging.py
+++ b/docs/examples/useful-tips/debugging.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -83,8 +83,8 @@ class TestDebugSnips(unittest.TestCase):
         assert df["uid"].tolist()[1:] == [2, 3]
         assert df["city"].tolist()[1:] == ["San Francisco", "New York"]
         assert df["signup_time"].tolist()[1:] == [
-            datetime(2021, 1, 1, 0, 0, 0),
-            datetime(2021, 1, 1, 0, 0, 0),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime(2021, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         ]
         assert df["country"].tolist()[1:] == ["US", "US"]
 
@@ -136,8 +136,8 @@ class TestDebugSnips(unittest.TestCase):
         assert df["uid"].tolist() == [2, 3]
         assert df["country"].tolist() == ["US", "US"]
         assert df["signup_time"].tolist() == [
-            pd.Timestamp("2021-02-01T00:00:00"),
-            pd.Timestamp("2021-03-01T00:00:00"),
+            pd.Timestamp("2021-02-01T00:00:00", tzinfo=timezone.utc),
+            pd.Timestamp("2021-03-01T00:00:00", tzinfo=timezone.utc),
         ]
         assert df.shape == (2, 3)
 

--- a/fennel/client_tests/branches/test_clone.py
+++ b/fennel/client_tests/branches/test_clone.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -186,7 +186,7 @@ def test_clone_after_log(client):
         featuresets=[UserInfoFeatureset],
     )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -232,7 +232,7 @@ def test_webhook_log_to_both_clone_parent(client):
     resp = client.clone_branch("test-branch", from_branch="main")
     assert resp.status_code == requests.codes.OK, resp.json()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -294,7 +294,7 @@ def test_add_dataset_clone_branch(client):
     )
     assert resp.status_code == requests.codes.OK, resp.json()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -354,7 +354,7 @@ def test_change_dataset_clone_branch(client):
     Clone a branch A → B. Verify A & B both give the same answers.
     Then modify A. Ensure B keeps giving the same answers.
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -434,7 +434,7 @@ def test_multiple_clone_branch(client):
     Clone A → B and then again B → C — they are all the same.
     Now modify B and C in different ways - so all three of A, B, C have different graphs/data etc.
     """
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -541,7 +541,7 @@ def test_change_source_dataset_clone_branch(client):
         datasets=_get_source_changed_datasets(),
     )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -567,7 +567,7 @@ def test_change_source_dataset_clone_branch(client):
     assert response.status_code == requests.codes.OK, response.json()
     client.sleep()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,
@@ -622,7 +622,7 @@ def test_change_extractor_clone_branch(client):
         featuresets=[_get_changed_featureset()],
     )
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,

--- a/fennel/client_tests/branches/test_create.py
+++ b/fennel/client_tests/branches/test_create.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -109,7 +109,7 @@ def test_log(client):
     )
     assert resp.status_code == 200, resp.json()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,

--- a/fennel/client_tests/branches/test_delete.py
+++ b/fennel/client_tests/branches/test_delete.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -77,7 +77,7 @@ def test_complex_delete(client):
     )
     client.clone_branch(name="test-branch", from_branch="main")
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "user_id": 1,

--- a/fennel/client_tests/test_additional_schemas.py
+++ b/fennel/client_tests/test_additional_schemas.py
@@ -1,14 +1,14 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
 
 import fennel._vendor.requests as requests
-from fennel.datasets import dataset, field
-from fennel.lib import meta
-from fennel.dtypes import oneof, regex, between
 from fennel.connectors import source, Webhook
+from fennel.datasets import dataset, field
+from fennel.dtypes import oneof, regex, between
+from fennel.lib import meta
 from fennel.testing import mock
 
 EMAIL_REGEX = r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+"
@@ -36,7 +36,7 @@ class TestDataset(unittest.TestCase):
     def test_log_with_additional_schema(self, client):
         # Log correct data
         client.commit(message="msg", datasets=[UserInfoDataset])
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             {
                 "user_id": 1,
@@ -53,7 +53,7 @@ class TestDataset(unittest.TestCase):
         assert response.status_code == requests.codes.OK, response.json()
 
         # Log incorrect data
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             {
                 "user_id": 1,
@@ -83,7 +83,7 @@ class TestDataset(unittest.TestCase):
                 "between, but the value `123` is out of bounds. Error found during checking schema for `UserInfoDataset`.')]"
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             {
                 "user_id": 1,
@@ -111,7 +111,7 @@ class TestDataset(unittest.TestCase):
                 == str(e.value)
             )
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             {
                 "user_id": 1,

--- a/fennel/client_tests/test_bounded_idleness.py
+++ b/fennel/client_tests/test_bounded_idleness.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -47,7 +47,7 @@ def test_idleness_for_bounded_source(client):
     )
 
     # Log 3 rows of data
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "display_id": 1,
@@ -73,7 +73,7 @@ def test_idleness_for_bounded_source(client):
     assert response.status_code == requests.codes.OK, response.json()
 
     # We should get data for keys 1 and 2 since they are logged above and no data for 4
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now, now, now])
     display_id_keys = pd.Series([1, 2, 4])
     df, _ = BoundedClicksDS.lookup(ts, display_id=display_id_keys)
@@ -82,7 +82,7 @@ def test_idleness_for_bounded_source(client):
 
     # Sleep for 2 seconds and log 2 more rows of data
     time.sleep(2)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "display_id": 4,
@@ -102,7 +102,7 @@ def test_idleness_for_bounded_source(client):
     assert response.status_code == requests.codes.OK, response.json()
 
     # We should get data for keys 4, 5 since they are logged above and no data for 6
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now, now, now])
     display_id_keys = pd.Series([4, 5, 6])
     df, _ = BoundedClicksDS.lookup(ts, display_id=display_id_keys)
@@ -111,7 +111,7 @@ def test_idleness_for_bounded_source(client):
 
     # Sleep for 5s so that new data which is not logged is not ingested since idleness for this source is 4s
     time.sleep(5)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "display_id": 6,
@@ -132,7 +132,7 @@ def test_idleness_for_bounded_source(client):
 
     # We should get data for key 1 since they are logged above and no data for 6, 7 since we logged the data after
     # the source is closed
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now, now, now])
     display_id_keys = pd.Series([1, 6, 7])
     df, _ = BoundedClicksDS.lookup(ts, display_id=display_id_keys)
@@ -147,7 +147,7 @@ def test_idleness_for_unbounded_source(client):
     )
 
     # Log 3 rows of data
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "display_id": 1,
@@ -173,7 +173,7 @@ def test_idleness_for_unbounded_source(client):
     assert response.status_code == requests.codes.OK, response.json()
 
     # We should get data for keys 1 and 2 since they are logged above and no data for 4
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now, now, now])
     display_id_keys = pd.Series([1, 2, 4])
     df, _ = UnBoundedClicksDS.lookup(ts, display_id=display_id_keys)
@@ -182,7 +182,7 @@ def test_idleness_for_unbounded_source(client):
 
     # Sleep for 2 seconds and log 2 more rows of data
     time.sleep(2)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "display_id": 4,
@@ -202,7 +202,7 @@ def test_idleness_for_unbounded_source(client):
     assert response.status_code == requests.codes.OK, response.json()
 
     # We should get data for keys 4, 5 since they are logged above and no data for 6
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now, now, now])
     display_id_keys = pd.Series([4, 5, 6])
     df, _ = UnBoundedClicksDS.lookup(ts, display_id=display_id_keys)
@@ -211,7 +211,7 @@ def test_idleness_for_unbounded_source(client):
 
     # Sleep for 5s and this new data gets ingested since the source is unbounded
     time.sleep(5)
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "display_id": 6,
@@ -231,7 +231,7 @@ def test_idleness_for_unbounded_source(client):
     assert response.status_code == requests.codes.OK, response.json()
 
     # We should get data for keys 1, 6, 7 since the data is logged above and source is unbounded
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now, now, now])
     display_id_keys = pd.Series([1, 6, 7])
     df, _ = UnBoundedClicksDS.lookup(ts, display_id=display_id_keys)

--- a/fennel/client_tests/test_complex_autogen_extractor.py
+++ b/fennel/client_tests/test_complex_autogen_extractor.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -170,9 +170,7 @@ class RiderFeatures:
     def extract_age_years(
         cls, ts: pd.Series, birthdate: pd.Series
     ) -> pd.DataFrame:
-        age_years = (datetime.utcnow() - birthdate).dt.total_seconds() / (
-            60 * 60 * 24 * 365
-        )
+        age_years = (ts - birthdate).dt.total_seconds() / (60 * 60 * 24 * 365)
         age_years = age_years.astype(int)
         return pd.DataFrame({"age_years": age_years})
 
@@ -293,8 +291,8 @@ def test_complex_auto_gen_extractors(client):
     rider_df = pd.DataFrame(
         {
             "rider_id": [1],
-            "created": [datetime.utcnow()],
-            "birthdate": [datetime.utcnow() - relativedelta(years=30)],
+            "created": [datetime.now(timezone.utc)],
+            "birthdate": [datetime.now(timezone.utc) - relativedelta(years=30)],
             "country_code": ["US"],
         }
     )
@@ -309,7 +307,7 @@ def test_complex_auto_gen_extractors(client):
             "rider_id": [1],
             "vehicle_id": [1],
             "is_completed_trip": [1],
-            "created": [datetime.utcnow()],
+            "created": [datetime.now(timezone.utc)],
         }
     )
     log_response = client.log(
@@ -322,7 +320,7 @@ def test_complex_auto_gen_extractors(client):
     country_license_df = pd.DataFrame(
         {
             "rider_id": [1],
-            "created": [datetime.utcnow()],
+            "created": [datetime.now(timezone.utc)],
             "country_code": ["US"],
         }
     )
@@ -346,7 +344,7 @@ def test_complex_auto_gen_extractors(client):
     assert extracted_df["RiderFeatures.dl_state"].to_list() == ["US", "Unknown"]
     assert extracted_df["RiderFeatures.is_us_dl"].to_list() == [True, False]
 
-    age_years = datetime.utcnow().year - 2000
+    age_years = datetime.now(timezone.utc).year - 2000
     assert extracted_df["RiderFeatures.age_years"].to_list() == [30, age_years]
     assert extracted_df["RiderFeatures.dl_state_population"].to_list() == [
         328200000,

--- a/fennel/client_tests/test_complex_struct.py
+++ b/fennel/client_tests/test_complex_struct.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Dict
 
 import pandas as pd
@@ -156,7 +156,7 @@ class MovieFeatures:
 
 
 def _log_movie_data(client):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         {
             "movie_id": 1,

--- a/fennel/client_tests/test_data_integration.py
+++ b/fennel/client_tests/test_data_integration.py
@@ -1,6 +1,6 @@
 import time
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -49,7 +49,7 @@ class TestMovieInfo103(unittest.TestCase):
         """Log some data to the dataset and check if it is logged correctly."""
         # Sync the dataset
         client.commit(message="msg", datasets=[MovieInfo103], tier="dev")
-        t = datetime.utcfromtimestamp(1672858163)
+        t = datetime.fromtimestamp(1672858163, tz=timezone.utc)
         data = [
             [
                 1,
@@ -69,7 +69,7 @@ class TestMovieInfo103(unittest.TestCase):
         client.sleep()
 
         # Do some lookups
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         keys = pd.DataFrame({"movieId": [1, 2, 23, 123343]})
         df, found = client.lookup(
             "MovieInfo103",
@@ -90,7 +90,7 @@ class TestMovieInfo103(unittest.TestCase):
         ]
 
         # Do some lookups with a timestamp
-        past = datetime.utcfromtimestamp(1672858160)
+        past = datetime.fromtimestamp(1672858160, tz=timezone.utc)
         ts = pd.Series([past, past, now, past])
         df, found = client.lookup(
             "MovieInfo103",
@@ -111,7 +111,7 @@ class TestMovieInfo103(unittest.TestCase):
         time.sleep(10)
 
         # Do some lookups
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         movie_ids = pd.Series([1, 2, 23, 123343])
         ts = pd.Series([now, now, now, now])
         df, found = MovieInfo103.lookup(
@@ -133,7 +133,7 @@ class TestMovieInfo103(unittest.TestCase):
         ]
 
         # Do some lookups with a timestamp
-        past = datetime.utcfromtimestamp(1672858160)
+        past = datetime.fromtimestamp(1672858160, tz=timezone.utc)
         ts = pd.Series([past, past, now, past])
         df, found = MovieInfo103.lookup(
             ts,
@@ -159,7 +159,7 @@ class TestMovieInfo103(unittest.TestCase):
                 24,
                 "Powder (1995)",
                 "Drama|Sci-Fi",
-                datetime.utcfromtimestamp(1672858163),
+                datetime.fromtimestamp(1672858163, tz=timezone.utc),
             ],
         ]
         columns = ["movieId", "title", "genres", "timestamp"]
@@ -178,8 +178,8 @@ class TestMovieInfo103(unittest.TestCase):
             "Powder (1995)",
         ]
         assert df["timestamp"].tolist() == [
-            datetime.utcfromtimestamp(1672858163),
-            datetime.utcfromtimestamp(1672858163),
-            datetime.utcfromtimestamp(1672858163),
-            datetime.utcfromtimestamp(1672858163),
+            datetime.fromtimestamp(1672858163, tz=timezone.utc),
+            datetime.fromtimestamp(1672858163, tz=timezone.utc),
+            datetime.fromtimestamp(1672858163, tz=timezone.utc),
+            datetime.fromtimestamp(1672858163, tz=timezone.utc),
         ]

--- a/fennel/client_tests/test_dataset.py
+++ b/fennel/client_tests/test_dataset.py
@@ -2,7 +2,7 @@ import json
 import re
 import time
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from math import sqrt
 from typing import Optional, List, Dict
 
@@ -110,7 +110,7 @@ class TestDataset(unittest.TestCase):
     def test_simple_log(self, client):
         # Sync the dataset
         client.commit(message="msg", datasets=[UserInfoDataset])
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         yesterday = now - pd.Timedelta(days=1)
         data = [
             [18232, "Ross", 32, "USA", now],
@@ -138,7 +138,7 @@ class TestDataset(unittest.TestCase):
             datasets=[UserInfoDatasetDerivedSelect],
             incremental=True,
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         yesterday = now - pd.Timedelta(days=1)
         data = [
             [18232, "Ross", 32, "USA", now],
@@ -185,7 +185,7 @@ class TestDataset(unittest.TestCase):
             datasets=[UserInfoDataset, UserInfoDatasetDerivedDropnull],
         )
         assert response.status_code == requests.codes.OK, response.json()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "Ross", 32, "USA", now],
             [18234, "Monica", None, "Chile", now],
@@ -254,7 +254,7 @@ class TestDataset(unittest.TestCase):
         client.commit(
             message="msg", datasets=[UserInfoDataset, UserInfoDatasetDerived]
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         yesterday = now - pd.Timedelta(days=1)
         data = [
             [18232, "Ross", 32, "USA", now],
@@ -294,7 +294,7 @@ class TestDataset(unittest.TestCase):
         # Sync the dataset
         client.commit(message="msg", datasets=[UserInfoDataset])
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         yesterday = now - pd.Timedelta(days=1)
         data = [
             [18232, "Ross", 32, "USA", now],
@@ -326,7 +326,7 @@ class TestDataset(unittest.TestCase):
         client.sleep(10)
         # Do some lookups
         user_ids = pd.Series([18232, 18234, 1920], dtype="Int64")
-        lookup_now = datetime.utcnow() + pd.Timedelta(minutes=1)
+        lookup_now = datetime.now(timezone.utc) + pd.Timedelta(minutes=1)
         ts = pd.Series([lookup_now, lookup_now, lookup_now])
         df, found = UserInfoDataset.lookup(
             ts,
@@ -337,7 +337,11 @@ class TestDataset(unittest.TestCase):
         assert df["age"].tolist() == [32, 24, None]
         assert df["country"].tolist() == ["USA", "Chile", None]
         if not client.is_integration_client():
-            assert df["timestamp"].tolist() == [now, yesterday, None]
+            assert df["timestamp"].tolist() == [
+                now,
+                yesterday,
+                None,
+            ]
         else:
             df["timestamp"] = df["timestamp"].apply(
                 lambda x: x.replace(second=0, microsecond=0)
@@ -481,7 +485,7 @@ class TestDataset(unittest.TestCase):
 #
 #         # Sync the dataset
 #         client.commit(datasets=[DocumentContentDataset])
-#         now = datetime.utcnow()
+#         now = datetime.now(timezone.utc)
 #         data = [
 #             [18232, np.array([1, 2, 3, 4]), np.array([1, 2, 3]), 10, now],
 #             [
@@ -682,7 +686,7 @@ class TestBasicTransform(unittest.TestCase):
             message="msg",
             datasets=[MovieRating, MovieRatingTransformed, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         two_hours_ago = now - timedelta(hours=2)
         data = [
             ["Jumanji", 4, 343, 789, two_hours_ago],
@@ -804,7 +808,7 @@ class TestBasicAssign(unittest.TestCase):
             message="msg",
             datasets=[MovieRating, MovieRatingAssign, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         two_hours_ago = now - timedelta(hours=2)
         data = [
             ["Jumanji", 4, 343, 789, two_hours_ago],
@@ -906,7 +910,7 @@ class TestBasicJoin(unittest.TestCase):
             message="msg",
             datasets=[MovieRating, MovieRevenue, MovieStats, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         data = [
             ["Jumanji", 4, 343, 789, one_hour_ago],
@@ -1042,7 +1046,7 @@ class TestInnerJoinExplodeDedup(unittest.TestCase):
             response.status_code == requests.codes.OK
         ), response.json()  # noqa
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         one_day_ago = now - timedelta(days=1)
         two_hours_ago = now - timedelta(hours=2)
@@ -1155,7 +1159,7 @@ class TestBasicAggregate(unittest.TestCase):
             message="msg",
             datasets=[MovieRatingCalculated, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         two_hours_ago = now - timedelta(hours=2)
         three_hours_ago = now - timedelta(hours=3)
@@ -1272,7 +1276,7 @@ class TestBasicWindowAggregate(unittest.TestCase):
             message="msg",
             datasets=[MovieRatingWindowed, RatingActivity],
         )
-        true_now = datetime.utcnow()
+        true_now = datetime.now(timezone.utc)
         now = true_now - timedelta(days=10) - timedelta(minutes=1)
         three_hours = now + timedelta(hours=3)
         six_hours = now + timedelta(hours=6)
@@ -1404,7 +1408,7 @@ class TestBasicWindowAggregate(unittest.TestCase):
             message="msg",
             datasets=[MovieRatingCalculated, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         two_hours_ago = now - timedelta(hours=2)
         three_hours_ago = now - timedelta(hours=3)
@@ -1488,7 +1492,7 @@ class TestBasicFilter(unittest.TestCase):
             message="msg",
             datasets=[PositiveRatingActivity, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         two_hours_ago = now - timedelta(hours=2)
         three_hours_ago = now - timedelta(hours=3)
@@ -1590,7 +1594,7 @@ class TestBasicCountUnique(unittest.TestCase):
             message="msg",
             datasets=[UniqueMoviesSeen, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         two_hours_ago = now - timedelta(hours=2)
         three_hours_ago = now - timedelta(hours=3)
@@ -1683,7 +1687,7 @@ class TestBasicDistinct(unittest.TestCase):
             message="msg",
             datasets=[UserUniqueMoviesSeen, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         two_hours_ago = now - timedelta(hours=2)
         three_hours_ago = now - timedelta(hours=3)
@@ -1777,7 +1781,7 @@ class TestLastOp(unittest.TestCase):
             message="msg",
             datasets=[LastMovieSeen, RatingActivity, NumTimesLastMovie],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         five_hours_ago = now - timedelta(hours=5)
         three_hours_ago = now - timedelta(hours=3)
         two_hours_ago = now - timedelta(hours=2)
@@ -1901,7 +1905,7 @@ class TestFirstOp(unittest.TestCase):
             message="msg",
             datasets=[FirstMovieSeen, RatingActivity, NumTimesFirstMovie],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         five_hours_ago = now - timedelta(hours=5)
         three_hours_ago = now - timedelta(hours=3)
         two_hours_ago = now - timedelta(hours=2)
@@ -1996,7 +2000,7 @@ class TestWaterMark(unittest.TestCase):
             message="msg",
             datasets=[FirstMovieSeenWithFilter, RatingActivity],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         minute_ago = now - timedelta(minutes=1)
         data = [
             [18231, 4.5, "Jumanji", minute_ago],
@@ -2144,7 +2148,7 @@ class TestNestedStructType(unittest.TestCase):
             message="msg",
             datasets=[DealerNumCars, Dealer],
         )
-        now = datetime.utcnow() - timedelta(hours=1)
+        now = datetime.now(timezone.utc) - timedelta(hours=1)
         data = {
             "name": ["Test Dealer", "Second Dealer", "Third Dealer"],
             "address": [
@@ -2200,7 +2204,7 @@ class TestNestedStructType(unittest.TestCase):
         assert response.status_code == requests.codes.OK, response.json()
         client.sleep()
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         # Verify the data by looking it up
         df, _ = Dealer.lookup(
             pd.Series([now, now]),
@@ -2324,7 +2328,7 @@ class TestFraudReportAggregatedDataset(unittest.TestCase):
             message="msg",
             datasets=[MerchantInfo, Activity, FraudReportAggregatedDataset],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         minute_ago = now - timedelta(minutes=1)
         data = [
             [
@@ -2404,7 +2408,7 @@ class TestFraudReportAggregatedDataset(unittest.TestCase):
 
         client.sleep()
 
-        now = datetime.utcnow() + timedelta(minutes=1)
+        now = datetime.now(timezone.utc) + timedelta(minutes=1)
         ts = pd.Series([now, now])
         categories = pd.Series(["grocery", "entertainment"])
         df, _ = FraudReportAggregatedDataset.lookup(ts, category=categories)
@@ -2494,9 +2498,9 @@ class TestAggregateTableDataset(unittest.TestCase):
             message="msg", datasets=[UserAge, UserAge2, UserAgeAggregated]
         )
         client.sleep()
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        now = datetime.utcnow()
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        now = datetime.now(timezone.utc)
+        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
 
         data = [
             ["Sonu", 24, "mumbai", yesterday],
@@ -2655,8 +2659,8 @@ class TestE2eIntegrationTestMUInfo(unittest.TestCase):
             message="msg",
             datasets=[PlayerInfo, ClubSalary, WAG, ManchesterUnitedPlayerInfo],
         )
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        minute_ago = datetime.utcnow() - timedelta(minutes=1)
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
+        minute_ago = datetime.now(timezone.utc) - timedelta(minutes=1)
         data = [
             ["Rashford", 25, 71, 154, "Manchester United", minute_ago],
             ["Maguire", 29, 76, 198, "Manchester United", minute_ago],
@@ -2742,7 +2746,7 @@ class TestE2eIntegrationTestMUInfoBounded(unittest.TestCase):
             ],
         )
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         minute_ago = now - timedelta(minutes=1)
         second_ahead = now + timedelta(seconds=1)
         minute_ahead = now + timedelta(minutes=1)
@@ -2878,7 +2882,7 @@ def test_join(client):
 
     client.commit(message="msg", datasets=[A, B, ABCDataset])
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     df1 = pd.DataFrame(
         {
             "a1": [1, 2, 3],
@@ -3097,17 +3101,17 @@ def LocationLatLong_wrapper_adace968e2(*args, **kwargs):
     data = [
         {
             "name": "LocationLatLong",
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(timezone.utc),
             "payload": '{"user_id": 247, "latitude": 12.3, "longitude": 12.3}',
         },
         {
             "name": "LocationLatLong",
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(timezone.utc),
             "payload": '{"user_id": 248, "latitude": 12.3, "longitude": 12.4}',
         },
         {
             "name": "LocationLatLong",
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(timezone.utc),
             "payload": '{"user_id": 246, "latitude": 12.3, "longitude": 12.3}',
         },
     ]
@@ -3116,7 +3120,7 @@ def LocationLatLong_wrapper_adace968e2(*args, **kwargs):
 
     client.sleep()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     timestamps = pd.Series([now, now])
     res, found = LocationLatLong.lookup(
         ts=timestamps, latlng2=pd.Series(["12.3-12.4", "12.3-12.3"])
@@ -3362,7 +3366,7 @@ def test_inner_join_column_name_collision(client):
         ],
     )
     assert initial.status_code == 200
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     stripe_charge_df = pd.DataFrame(
         {"customer": [1], "created": [now], "outcome_risk_score": [0.5]}
@@ -3432,7 +3436,7 @@ class UserInfoDatasetPreProc:
 def test_dataset_with_pre_proc_log(client):
     # Sync the dataset
     client.commit(message="msg", datasets=[UserInfoDatasetPreProc])
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         [18232, "Ross", "USA"],
         [18234, "Monica", "Chile"],
@@ -3456,7 +3460,7 @@ def test_dataset_with_pre_proc_log(client):
         10,
     ]  # should return the default value of 10 assigned above
     assert df["country"].tolist() == ["USA", "Chile"]
-    epoch = datetime(1970, 1, 1, 0, 0, 0)
+    epoch = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     assert df["timestamp"].tolist() == [epoch, epoch]
 
 
@@ -3565,7 +3569,7 @@ def test_erase_key(client):
     assert found.tolist() == [False]
 
     # Should be deleted as of
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data, found = client.lookup(
         "UserInfoDatasetDerived",
         pd.DataFrame({"user_id": [18232]}),

--- a/fennel/client_tests/test_featureset.py
+++ b/fennel/client_tests/test_featureset.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, List
 
 import numpy as np
@@ -197,7 +197,7 @@ class TestSimpleExtractor(unittest.TestCase):
             datasets=[UserInfoDataset],
             featuresets=[UserInfoMultipleExtractor],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "John", 32, "USA", now],
             [18234, "Monica", 24, "Chile", now],
@@ -299,7 +299,7 @@ class TestDerivedExtractor(unittest.TestCase):
                 FlightRequest,
             ],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "John", 32, "USA", now],
             [18234, "Monica", 24, "Chile", now],
@@ -391,7 +391,7 @@ class TestExtractorDAGResolution(unittest.TestCase):
             datasets=[UserInfoDataset],
             featuresets=[UserInfoMultipleExtractor],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "John", 32, "USA", now],
             [18234, "Monica", 24, "Chile", now],
@@ -477,7 +477,7 @@ class TestExtractorDAGResolutionComplex(unittest.TestCase):
             ],
         )
         client.sleep()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, "John", 32, "USA", now],
             [18234, "Monica", 24, "Chile", now],
@@ -608,7 +608,7 @@ class TestDocumentDataset(unittest.TestCase):
             datasets=[DocumentContentDataset],
             featuresets=[DocumentFeatures],
         )
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [18232, np.array([1, 2, 3, 4]), np.array([1, 2, 3]), 10, now],
             [
@@ -662,7 +662,7 @@ class TestDocumentDataset(unittest.TestCase):
         if client.is_integration_client():
             return
 
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
 
         feature_df = client.query_offline(
             outputs=[DocumentFeatures],

--- a/fennel/client_tests/test_fraud_detection.py
+++ b/fennel/client_tests/test_fraud_detection.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -150,7 +150,7 @@ def test_fraud_detection_pipeline(client):
     region_to_state = region_to_state.rename(columns={0: "region"}).reset_index(
         drop=True
     )
-    region_to_state.insert(0, "created_at", datetime.utcnow())
+    region_to_state.insert(0, "created_at", datetime.now(timezone.utc))
     # Upload transaction_data dataframe to the Transactions dataset on the mock client
     transaction_data_sample = pd.read_csv(
         "fennel/client_tests/data/fraud_sample.csv"

--- a/fennel/client_tests/test_hopping_window_operator.py
+++ b/fennel/client_tests/test_hopping_window_operator.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pandas as pd
@@ -183,14 +183,18 @@ def test_hopping_window_operator(client):
 
     client.sleep()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now])
     user_id_keys = pd.Series([1])
     window_keys = pd.Series(
         [
             {
-                "begin": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 0)),
-                "end": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 10)),
+                "begin": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 0, tzinfo=timezone.utc)
+                ),
+                "end": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 10, tzinfo=timezone.utc)
+                ),
             }
         ]
     )
@@ -209,10 +213,10 @@ def test_hopping_window_operator(client):
     assert df_session.shape[0] == 1
     assert df_session["user_id"].values == [1]
     assert df_session["window"].values[0].begin == datetime(
-        2023, 1, 16, 11, 0, 0
+        2023, 1, 16, 11, 0, 0, tzinfo=timezone.utc
     )
     assert df_session["window"].values[0].end == datetime(
-        2023, 1, 16, 11, 0, 10
+        2023, 1, 16, 11, 0, 10, tzinfo=timezone.utc
     )
     assert df_session["window_stats"].values[0].count == 6
     assert df_session["window_stats"].values[0].avg_star == pytest.approx(

--- a/fennel/client_tests/test_movie_tickets.py
+++ b/fennel/client_tests/test_movie_tickets.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 import pytest
 
@@ -249,7 +249,7 @@ class TestMovieTicketSale(unittest.TestCase):
             response.status_code == requests.codes.OK
         ), response.json()  # noqa
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         one_hour_ago = now - timedelta(hours=1)
         one_day_ago = now - timedelta(days=1)
         two_hours_ago = now - timedelta(hours=2)

--- a/fennel/client_tests/test_outbrain.py
+++ b/fennel/client_tests/test_outbrain.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 import pytest
@@ -117,7 +117,7 @@ def test_outbrain(client):
         "fennel/client_tests/data/page_views_sample.csv"
     ).sort_values(by=["timestamp"])
     # Current time in ms
-    cur_time_ms = datetime.utcnow().timestamp() * 1000
+    cur_time_ms = datetime.now(timezone.utc).timestamp() * 1000
     max_ts = max(df["timestamp"].tolist())
     # Shift all the data such that the most recent data point has timestamp = cur_time_ms
     df["timestamp"] = df["timestamp"] + cur_time_ms - max_ts
@@ -126,7 +126,7 @@ def test_outbrain(client):
     twelve_days = 12 * 24 * 60 * 60 * 1000
     df = df[df["timestamp"] > cur_time_ms - twelve_days]
     df["timestamp"] = df["timestamp"].apply(
-        lambda x: datetime.fromtimestamp(x / 1000)
+        lambda x: datetime.fromtimestamp(x / 1000, tz=timezone.utc)
     )
 
     client.log("outbrain_webhook", "PageViews", df)

--- a/fennel/client_tests/test_search.py
+++ b/fennel/client_tests/test_search.py
@@ -1,6 +1,6 @@
 import unittest
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List
 
 import numpy as np
@@ -437,7 +437,7 @@ class TopWordsFeatures:
 
 class TestSearchExample(unittest.TestCase):
     def log_document_data(self, client):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [141234, "This is a random document", "Random Title", "Sagar", now],
             [
@@ -506,7 +506,7 @@ class TestSearchExample(unittest.TestCase):
         assert response.status_code == requests.codes.OK, response.json()
 
     def log_engagement_data(self, client):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         data = [
             [123, 31234, "view", 5, now],
             [123, 143354, "view", 1, now],
@@ -538,7 +538,7 @@ class TestSearchExample(unittest.TestCase):
         )
         self.log_document_data(client)
         client.sleep()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         yesterday = now - pd.Timedelta(days=1)
 
         doc_ids = pd.DataFrame({"doc_id": [141234, 143354, 33234, 11111]})
@@ -572,7 +572,7 @@ class TestSearchExample(unittest.TestCase):
 
         self.log_engagement_data(client)
         client.sleep(20)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         ts = pd.Series([now, now])
         user_ids = pd.Series([123, 342])
         df, found = UserEngagementDataset.lookup(ts, user_id=user_ids)

--- a/fennel/client_tests/test_session_window_operator.py
+++ b/fennel/client_tests/test_session_window_operator.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pandas as pd
@@ -187,15 +187,26 @@ def test_session_window_operator(client):
 
     client.sleep()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now])
     user_id_keys = pd.Series([1])
     window_keys = pd.Series(
         [
             {
-                "begin": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 25)),
+                "begin": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 25, tzinfo=timezone.utc)
+                ),
                 "end": pd.Timestamp(
-                    datetime(2023, 1, 16, 11, 0, 33, microsecond=1)
+                    datetime(
+                        2023,
+                        1,
+                        16,
+                        11,
+                        0,
+                        33,
+                        microsecond=1,
+                        tzinfo=timezone.utc,
+                    )
                 ),
             }
         ]
@@ -214,10 +225,10 @@ def test_session_window_operator(client):
     assert df_session.shape[0] == 1
     assert list(df_session["user_id"].values) == [1]
     assert df_session["window"].values[0].begin == datetime(
-        2023, 1, 16, 11, 0, 25
+        2023, 1, 16, 11, 0, 25, tzinfo=timezone.utc
     )
     assert df_session["window"].values[0].end == datetime(
-        2023, 1, 16, 11, 0, 33, microsecond=1
+        2023, 1, 16, 11, 0, 33, microsecond=1, tzinfo=timezone.utc
     )
     assert df_session["window_stats"].values[0].count == 8
     assert df_session["window_stats"].values[0].avg_star == 3.125

--- a/fennel/client_tests/test_social_network.py
+++ b/fennel/client_tests/test_social_network.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pandas as pd
@@ -232,6 +232,7 @@ def test_social_network(client):
     assert res.status_code == requests.codes.OK, res.json()
     res = client.log("fennel_webhook", "ViewData", view_data_df)
     assert res.status_code == requests.codes.OK, res.json()
+
     if client.is_integration_client():
         client.sleep(120)
 

--- a/fennel/client_tests/test_struct_type.py
+++ b/fennel/client_tests/test_struct_type.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pandas as pd
@@ -90,7 +90,7 @@ class MovieFeatures:
 
 
 def log_movie_data(client):
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         [
             {"movie_id": 101, "title": "Inception"},

--- a/fennel/client_tests/test_tumbling_window_operator.py
+++ b/fennel/client_tests/test_tumbling_window_operator.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pandas as pd
@@ -294,14 +294,18 @@ def test_tumbling_window_operator(client):
 
     client.sleep()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now])
     user_id_keys = pd.Series([1])
     window_keys = pd.Series(
         [
             {
-                "begin": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 0)),
-                "end": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 10)),
+                "begin": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 0, tzinfo=timezone.utc)
+                ),
+                "end": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 10, tzinfo=timezone.utc)
+                ),
             }
         ]
     )
@@ -319,10 +323,10 @@ def test_tumbling_window_operator(client):
     assert df_session.shape[0] == 1
     assert df_session["user_id"].values == [1]
     assert df_session["window"].values[0].begin == datetime(
-        2023, 1, 16, 11, 0, 0
+        2023, 1, 16, 11, 0, 0, tzinfo=timezone.utc
     )
     assert df_session["window"].values[0].end == datetime(
-        2023, 1, 16, 11, 0, 10
+        2023, 1, 16, 11, 0, 10, tzinfo=timezone.utc
     )
     assert df_session["window_stats"].values[0].count == 6
     assert df_session["window_stats"].values[0].avg_star == pytest.approx(
@@ -392,14 +396,18 @@ def test_tumbling_hopping_equivalent_operator(client):
 
     client.sleep()
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     ts = pd.Series([now])
     user_id_keys = pd.Series([1])
     window_keys = pd.Series(
         [
             {
-                "begin": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 0)),
-                "end": pd.Timestamp(datetime(2023, 1, 16, 11, 0, 10)),
+                "begin": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 0, tzinfo=timezone.utc)
+                ),
+                "end": pd.Timestamp(
+                    datetime(2023, 1, 16, 11, 0, 10, tzinfo=timezone.utc)
+                ),
             }
         ]
     )

--- a/fennel/connectors/connectors.py
+++ b/fennel/connectors/connectors.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, List, Optional, TypeVar, Union, Tuple, Dict
 from typing import Literal
 
 from fennel._vendor.pydantic import BaseModel, Field  # type: ignore
 from fennel._vendor.pydantic import validator  # type: ignore
+from fennel.connectors.kinesis import at_timestamp
 from fennel.internal_lib.duration import (
     Duration,
 )
 from fennel.internal_lib.duration.duration import is_valid_duration
 from fennel.lib.includes import TierSelector
-from fennel.connectors.kinesis import at_timestamp
 
 T = TypeVar("T")
 SOURCE_FIELD = "__fennel_data_sources__"
@@ -647,7 +647,7 @@ class S3Connector(DataConnector):
                 suffix_portion = True
                 # ensure we have a valid strftime format specifier
                 try:
-                    formatted = datetime.utcnow().strftime(part)
+                    formatted = datetime.now(timezone.utc).strftime(part)
                     datetime.strptime(formatted, part)
                     suffix.append(part)
                 except ValueError:

--- a/fennel/connectors/kinesis.py
+++ b/fennel/connectors/kinesis.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Union is needed pre Python 3.10
 from typing import Union
@@ -22,7 +22,7 @@ class at_timestamp(object):
         if isinstance(timestamp, datetime):
             self.timestamp = timestamp
         elif isinstance(timestamp, (int, float)):
-            self.timestamp = datetime.utcfromtimestamp(timestamp)
+            self.timestamp = datetime.fromtimestamp(timestamp, tz=timezone.utc)
         elif isinstance(timestamp, str):
             self.timestamp = datetime.fromisoformat(timestamp)
         else:

--- a/fennel/connectors/test_invalid_connectors.py
+++ b/fennel/connectors/test_invalid_connectors.py
@@ -1,10 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pytest
 
-from fennel.datasets import dataset, field
-from fennel.lib import meta
 from fennel.connectors import (
     source,
     Mongo,
@@ -19,6 +17,8 @@ from fennel.connectors import (
     BigQuery,
     S3Connector,
 )
+from fennel.datasets import dataset, field
+from fennel.lib import meta
 
 # noinspection PyUnresolvedReferences
 from fennel.testing import *
@@ -221,7 +221,7 @@ def test_invalid_kinesis_source():
         @source(
             kinesis.stream(
                 "test_stream",
-                at_timestamp(datetime.utcnow()),
+                at_timestamp(datetime.now(timezone.utc)),
                 format="csv",
             )
         )

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -65,6 +65,7 @@ from fennel.internal_lib.schema import (
 from fennel.internal_lib.utils import (
     dtype_to_string,
     get_origin,
+    parse_datetime,
 )
 from fennel.lib.expectations import Expectations, GE_ATTR_FUNC
 from fennel.lib.includes import TierSelector
@@ -1140,10 +1141,12 @@ def dataset(
                 raise ValueError(
                     f"Lookup for dataset `{cls_name}` expects a series of timestamps, found {type(ts)}"
                 )
-            if not np.issubdtype(ts.dtype, np.datetime64):
+            if not pd.api.types.is_datetime64_any_dtype(ts.dtype):
                 raise ValueError(
                     f"Lookup for dataset `{cls_name}` expects a series of timestamps, found {ts.dtype}"
                 )
+            # Parse the timestamp
+            ts = ts.apply(lambda x: parse_datetime(x))
             # extract keys and fields from kwargs
             arr = []
             for key in key_fields:

--- a/fennel/datasets/test_dataset_lookup.py
+++ b/fennel/datasets/test_dataset_lookup.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, no_type_check
 
 import pandas as pd
@@ -30,7 +30,7 @@ class UserInfoDataset:
 def fake_func(
     cls_name: str, ts: pd.Series, fields: List[str], df: pd.DataFrame
 ):
-    now = datetime.utcfromtimestamp(1668368655)
+    now = datetime.fromtimestamp(1668368655, tz=timezone.utc)
     if len(fields) > 0:
         assert ts.equals(pd.Series([now, now, now]))
         assert fields == ["age", "gender"]
@@ -106,7 +106,7 @@ def test_dataset_lookup():
     assert user_sq_extractor.name == "user_age_sq"
 
     user_sq_extractor_func = get_extractor_func(sync_request.extractors[1])
-    now = datetime.utcfromtimestamp(1668368655)
+    now = datetime.fromtimestamp(1668368655, tz=timezone.utc)
     ts = pd.Series([now, now, now])
     user_id = pd.Series([1, 2, 3])
     names = pd.Series(["a", "b", "c"])

--- a/fennel/datasets/test_invalid_dataset.py
+++ b/fennel/datasets/test_invalid_dataset.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List, Union
 
 import pandas as pd
@@ -965,9 +965,9 @@ def test_invalid_assign_schema(client):
             "latitude": [1.12312, 2.3423423, 2.24343],
             "longitude": [1.12312, 2.3423423, 2.24343],
             "created": [
-                datetime.utcfromtimestamp(1672858163),
-                datetime.utcfromtimestamp(1672858163),
-                datetime.utcfromtimestamp(1672858163),
+                datetime.fromtimestamp(1672858163, tz=timezone.utc),
+                datetime.fromtimestamp(1672858163, tz=timezone.utc),
+                datetime.fromtimestamp(1672858163, tz=timezone.utc),
             ],
         }
     )

--- a/fennel/internal_lib/schema/schema.py
+++ b/fennel/internal_lib/schema/schema.py
@@ -453,7 +453,7 @@ def validate_field_in_df(
     elif dtype == schema_proto.DataType(
         timestamp_type=schema_proto.TimestampType()
     ):
-        if df[name].dtype != "datetime64[ns]":
+        if df[name].dtype not in ["datetime64[ns, UTC]"]:
             raise ValueError(
                 f"Field `{name}` is of type timestamp, but the "
                 f"column in the dataframe is of type "

--- a/fennel/internal_lib/schema/test_schema.py
+++ b/fennel/internal_lib/schema/test_schema.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -39,7 +39,7 @@ def test_get_data_type():
     assert get_datatype(type(x)) == proto.DataType(
         string_type=proto.StringType()
     )
-    x: datetime = datetime.utcnow()
+    x: datetime = datetime.now(timezone.utc)
 
     assert get_datatype(type(x)) == proto.DataType(
         timestamp_type=proto.TimestampType()
@@ -174,7 +174,8 @@ def test_additional_dtypes_invalid():
 
 
 def test_valid_schema():
-    now = datetime.utcnow()
+    # Replacing tzinfo because the data schema checks expects dtype to be datetime[ns] and not datetime[ns, UTC]
+    now = datetime.now(timezone.utc)
     yesterday = now - timedelta(days=1)
 
     data = [
@@ -305,7 +306,8 @@ def test_valid_schema():
 
 
 def test_invalid_schema():
-    now = datetime.utcnow()
+    # Replacing tzinfo because the data schema checks expects dtype to be datetime[ns] and not datetime[ns, UTC]
+    now = datetime.now(timezone.utc)
     yesterday = now - timedelta(days=1)
 
     data = [
@@ -436,7 +438,8 @@ def test_invalid_schema():
 
 
 def test_invalid_schema_additional_types():
-    now = datetime.utcnow()
+    # Replacing tzinfo because the data schema checks expects dtype to be datetime[ns] and not datetime[ns, UTC]
+    now = datetime.now(timezone.utc)
     data = [
         [18232, "Ross9", 212, "transgender", 5, now],
     ]

--- a/fennel/internal_lib/to_proto/test_source_code.py
+++ b/fennel/internal_lib/to_proto/test_source_code.py
@@ -85,7 +85,7 @@ class UserFeature:
     @outputs("age")
     def get_age(cls, ts: pd.Series, uids: pd.Series):
         dobs = User.lookup(ts=ts, uid=uids, fields=["dob"])  # type: ignore
-        # Using ts instead of datetime.utcnow() to make extract_historical work as of for the extractor
+        # Using ts instead of datetime.now(timezone.utc) to make extract_historical work as of for the extractor
         ages = ts - dobs
         return pd.Series(ages)
 

--- a/fennel/internal_lib/utils/__init__.py
+++ b/fennel/internal_lib/utils/__init__.py
@@ -3,4 +3,5 @@ from fennel.internal_lib.utils.utils import (
     get_origin,
     is_user_defined_class,
     as_json,
+    parse_datetime,
 )

--- a/fennel/internal_lib/utils/utils.py
+++ b/fennel/internal_lib/utils/utils.py
@@ -1,4 +1,5 @@
 import dataclasses
+from datetime import datetime
 from typing import Any, Union
 
 import pandas as pd
@@ -61,3 +62,23 @@ def as_json(self):
         value = getattr(self, field.name)
         result[field.name] = to_dict(value)
     return result
+
+
+def parse_datetime(value: Union[int, str, datetime]) -> datetime:
+    if isinstance(value, int):
+        try:
+            value = pd.to_datetime(value, unit="s")
+        except ValueError:
+            try:
+                value = pd.to_datetime(value, unit="ms")
+            except ValueError:
+                value = pd.to_datetime(value, unit="us")
+    else:
+        value = pd.to_datetime(value)
+
+    if value.tzinfo is not None:  # type: ignore
+        if str(value.tzinfo) != "UTC":  # type: ignore
+            value = value.tz_convert("UTC")  # type: ignore
+    else:
+        value = value.tz_localize("UTC")  # type: ignore
+    return value  # type: ignore

--- a/fennel/lib/includes/test_includes.py
+++ b/fennel/lib/includes/test_includes.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -105,7 +105,7 @@ def test_simple_extractor(client):
         datasets=[UserInfoDataset],
         featuresets=[UserInfoSingleExtractor],
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         [18232, "John", 32, "USA", now],
         [18234, "Monica", 24, "Chile", now],

--- a/fennel/lib/includes/test_includes_invalid.py
+++ b/fennel/lib/includes/test_includes_invalid.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -78,7 +78,7 @@ def test_simple_invalid_extractor(client):
         datasets=[UserInfoDataset],
         featuresets=[UserInfoExtractor],
     )
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     data = [
         [18232, "John", 32, "USA", now],
         [18234, "Monica", 24, "Chile", now],

--- a/fennel/testing/data_engine.py
+++ b/fennel/testing/data_engine.py
@@ -2,8 +2,9 @@ import copy
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime, timezone
 from functools import partial
-from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Callable, Any
 
 import numpy as np
@@ -11,6 +12,7 @@ import pandas as pd
 from frozendict import frozendict
 
 import fennel.datasets.datasets
+from fennel.connectors import connectors, PreProcValue
 from fennel.datasets import Dataset, Pipeline
 from fennel.datasets.datasets import (
     get_index,
@@ -20,13 +22,12 @@ from fennel.gen.dataset_pb2 import CoreDataset
 from fennel.internal_lib.duration import Duration, duration_to_timedelta
 from fennel.internal_lib.schema import data_schema_check
 from fennel.internal_lib.to_proto import dataset_to_proto
-from fennel.connectors import connectors, PreProcValue
+from fennel.internal_lib.utils import parse_datetime
 from fennel.testing.executor import Executor
 from fennel.testing.test_utils import (
     FakeResponse,
     cast_df_to_schema,
 )
-from dataclasses import field
 
 TEST_PORT = 50051
 TEST_DATA_PORT = 50052
@@ -50,7 +51,10 @@ def _preproc_df(
                 )
             new_df[col] = df[col_name]
         else:
-            new_df[col] = pre_proc_value
+            if isinstance(pre_proc_value, datetime):
+                new_df[col] = parse_datetime(pre_proc_value)
+            else:
+                new_df[col] = pre_proc_value
     return new_df
 
 
@@ -204,7 +208,7 @@ class DataEngine(object):
                     bounded=bounded,
                     pre_proc=pre_proc,
                     idleness=idleness,
-                    prev_log_time=datetime.utcnow(),
+                    prev_log_time=datetime.now(timezone.utc),
                     erased_keys=[],
                 )
 
@@ -614,7 +618,7 @@ class DataEngine(object):
                 idleness
             ).total_seconds()
             actual_idleness_secs = (
-                datetime.utcnow() - prev_log_time
+                datetime.now(timezone.utc) - prev_log_time
             ).total_seconds()
             # Do not log the data if a bounded source is idle for more time than expected
             if actual_idleness_secs >= expected_idleness_secs:
@@ -648,11 +652,11 @@ class DataEngine(object):
 
         # Check if the dataframe has the same schema as the dataset
         schema = core_dataset.dsschema
-        if str(df[timestamp_field].dtype) != "datetime64[ns]":
+        if str(df[timestamp_field].dtype) != "datetime64[ns, UTC]":
             raise ValueError(
                 400,
                 f"Timestamp field {timestamp_field} is not of type "
-                f"datetime64[ns] but found {df[timestamp_field].dtype} in "
+                f"datetime64[ns, UTC] but found {df[timestamp_field].dtype} in "
                 f"dataset {dataset_name}",
             )
         exceptions = data_schema_check(schema, df, dataset_name)
@@ -745,7 +749,9 @@ class DataEngine(object):
                 dataset_name
             ].dataset.timestamp_field
             self.datasets[dataset_name].data = df.sort_values(timestamp_field)
-            self.datasets[dataset_name].prev_log_time = datetime.utcnow()
+            self.datasets[dataset_name].prev_log_time = datetime.now(
+                timezone.utc
+            )
 
     def _process_data_connector(
         self, dataset: Dataset, tier: Optional[str] = None

--- a/fennel/testing/executor.py
+++ b/fennel/testing/executor.py
@@ -1,7 +1,7 @@
 import copy
 import types
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Dict, List
 
 import numpy as np
@@ -253,7 +253,7 @@ class Executor(Visitor):
         # is the timestamp below which we will not consider any rows from the right dataframe for joins
         def sub_within_low(row):
             if obj.within[0] == "forever":
-                return datetime.min
+                return datetime.min.replace(tzinfo=timezone.utc)
             else:
                 return row[left_timestamp_field] - duration_to_timedelta(
                     obj.within[0]
@@ -682,9 +682,13 @@ class Executor(Visitor):
                         windows_map[end] = (
                             WindowStruct(
                                 event_start=pd.Timestamp(
-                                    end - duration, unit="s"
+                                    end - duration,
+                                    unit="s",
+                                    tzinfo=timezone.utc,
                                 ),
-                                event_end=pd.Timestamp(end, unit="s"),
+                                event_end=pd.Timestamp(
+                                    end, unit="s", tzinfo=timezone.utc
+                                ),
                             ),
                             [],
                         )

--- a/fennel/testing/query_engine.py
+++ b/fennel/testing/query_engine.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
-from typing import Dict, List, Union, Optional, Any, Tuple
+from typing import Dict, List, Union, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -78,7 +78,12 @@ class QueryEngine:
                 ),
             )
             if timestamps is not None
-            else pd.Series([datetime.utcnow() for _ in range(len(keys))])
+            else cast_col_to_dtype(
+                pd.Series([datetime.now(timezone.utc)] * len(keys)),
+                schema_proto.DataType(
+                    timestamp_type=schema_proto.TimestampType()
+                ),
+            )
         )
         keys = keys.to_dict(orient="records")
 

--- a/fennel/testing/test_cast_df_to_schema.py
+++ b/fennel/testing/test_cast_df_to_schema.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import pandas as pd
@@ -20,7 +20,7 @@ def test_cast_int():
     df = pd.DataFrame(
         {
             "int_field": ["1", "2", "3"],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)
@@ -37,7 +37,7 @@ def test_cast_string():
     df = pd.DataFrame(
         {
             "string_field": [123, 456, 789],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)
@@ -54,7 +54,7 @@ def test_cast_optional_string():
     df = pd.DataFrame(
         {
             "int_field": ["123", None, "789"],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)
@@ -76,7 +76,7 @@ def test_cast_bool():
     df = pd.DataFrame(
         {
             "bool_field": [1, 0, 1],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)
@@ -97,7 +97,7 @@ def test_cast_type_restrictions():
             "age": ["21", "22", "23"],
             "gender": [1, 2, 3],
             "email": [1223423, 1223423, 1223423],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)
@@ -122,7 +122,10 @@ def test_cast_timestamp():
     schema = fields_to_dsschema(TestDataset.fields)
     result_df = cast_df_to_schema(df, schema)
     expected_timestamps = pd.Series(
-        [datetime(2021, 1, 1), datetime(2021, 1, 2)]
+        [
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+            datetime(2021, 1, 2, tzinfo=timezone.utc),
+        ]
     )
     assert all(result_df["created_ts"] == expected_timestamps)
     assert result_df["created_ts"].dtype == expected_timestamps.dtype
@@ -144,7 +147,10 @@ def test_cast_timestamp_with_timezone():
     schema = fields_to_dsschema(TestDataset.fields)
     result_df = cast_df_to_schema(df, schema)
     expected_timestamps = pd.Series(
-        [datetime(2021, 1, 1), datetime(2021, 1, 2)]
+        [
+            datetime(2021, 1, 1, tzinfo=timezone.utc),
+            datetime(2021, 1, 2, tzinfo=timezone.utc),
+        ]
     )
     assert all(result_df["created_ts"] == expected_timestamps)
     assert result_df["created_ts"].dtype == expected_timestamps.dtype
@@ -183,7 +189,7 @@ def test_null_in_non_optional_field():
     df = pd.DataFrame(
         {
             "non_optional_field": [1, None, 2],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)
@@ -204,7 +210,7 @@ def test_cast_failure_for_incorrect_type():
     df = pd.DataFrame(
         {
             "int_field": ["not_an_int", "123", "456"],
-            "created_ts": [datetime.utcnow() for _ in range(3)],
+            "created_ts": [datetime.now(timezone.utc) for _ in range(3)],
         }
     )
     schema = fields_to_dsschema(TestDataset.fields)


### PR DESCRIPTION
1. moved datetime.utcnow() to datetime.now(UTC)
2. Now mock client will convert the datetime logged by use into UTC everywhere, even the window start end keys will have UTC in them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
    - Updated examples and guides to ensure consistent timestamp handling across all documentation.
- **Bug Fixes**
    - Improved compatibility with Pandas data types for datetime handling in datasets.
- **Refactor**
    - Standardized datetime usage across various testing and client modules to ensure consistent timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->