### PR TITLE
Allow emit strategy and remove requirement of aggregation being a terminal operator on Mock Client 

### DIFF
--- a/docs/examples/api-reference/aggregations/max.py
+++ b/docs/examples/api-reference/aggregations/max.py
@@ -102,7 +102,7 @@ def test_basic(client):
     df, found = Aggregated.lookup(ts, uid=pd.Series([1, 2, 3]))
     assert found.tolist() == [True, True, True]
     assert df["uid"].tolist() == [1, 2, 3]
-    assert df["max_1d"].tolist() == [None, None, 60]
+    assert df["max_1d"].tolist() == [-1, -1, 60]
     assert df["max_1w"].tolist() == [20, 40, 60]
 
 

--- a/docs/examples/api-reference/aggregations/min.py
+++ b/docs/examples/api-reference/aggregations/min.py
@@ -102,7 +102,7 @@ def test_basic(client):
     df, found = Aggregated.lookup(ts, uid=pd.Series([1, 2, 3]))
     assert found.tolist() == [True, True, True]
     assert df["uid"].tolist() == [1, 2, 3]
-    assert df["min_1d"].tolist() == [None, None, 50]
+    assert df["min_1d"].tolist() == [-1, -1, 50]
     assert df["min_1w"].tolist() == [10, 30, 50]
 
 

--- a/fennel/datasets/test_dataset.py
+++ b/fennel/datasets/test_dataset.py
@@ -1454,7 +1454,8 @@ def test_dataset_with_complex_pipe():
                         into_field=str(cls.median_transaction_amount),
                         approx=True,
                     ),
-                ]
+                ],
+                emit="final",
             )
 
     view = InternalTestClient()
@@ -1662,6 +1663,7 @@ def test_dataset_with_complex_pipe():
                     }
                 },
             ],
+            "emitStrategy": "Final",
         },
         "ds_version": 1,
     }

--- a/fennel/datasets/test_schema_validator.py
+++ b/fennel/datasets/test_schema_validator.py
@@ -482,39 +482,6 @@ def test_aggregation_along():
         str(e.value)
         == """error with along kwarg of aggregate operator: `transaction_time` is not of type datetime"""
     )
-    with pytest.raises(ValueError) as e:
-
-        @meta(owner="nikhil@fennel.ai")
-        @dataset
-        class A4:
-            a: str = field(key=True)
-            b: int
-            t: datetime = field(timestamp=True)
-            transaction_time: int
-
-        @meta(owner="nikhil@fennel.ai")
-        @dataset
-        class B4:
-            a: str = field(key=True)
-            b_max: int
-            t: datetime
-
-            @pipeline
-            @inputs(A2)
-            def pipeline(cls, a: Dataset):
-                return a.groupby("a").aggregate(
-                    emit=Max(
-                        of="b",
-                        into_field="b_max",
-                        window="1d",
-                        default=1.91,
-                    ),
-                )
-
-    assert (
-        str(e.value)
-        == """`emit` is a reserved kwarg for aggregate operator and can not be used for an aggregation column"""
-    )
 
     with pytest.raises(ValueError) as e:
 
@@ -554,6 +521,80 @@ def test_aggregation_along():
     assert (
         """`along` kwarg in the aggregate operator must be string or None"""
         in str(e.value)
+    )
+
+
+def test_aggregation_emit():
+    with pytest.raises(ValueError) as e:
+
+        @meta(owner="nikhil@fennel.ai")
+        @dataset
+        class A1:
+            a: str = field(key=True)
+            b: int
+            t: datetime
+
+        @meta(owner="nikhil@fennel.ai")
+        @dataset
+        class B1:
+            a: str = field(key=True)
+            b_min: int
+            t: datetime
+
+            @pipeline
+            @inputs(A1)
+            def pipeline(cls, a: Dataset):
+                return a.groupby("a").aggregate(
+                    [
+                        Min(
+                            of="b",
+                            into_field="b_min",
+                            window="1d",
+                            default=0.91,
+                        ),
+                    ],
+                    emit="finall",
+                )
+
+    assert (
+        str(e.value)
+        == """`finall` is not a valid 'emit_strategy' in 'aggregate' operator. 'emit' in aggregation operator must be one of ['final', 'eager']"""
+    )
+    with pytest.raises(ValueError) as e:
+
+        @meta(owner="nikhil@fennel.ai")
+        @dataset
+        class A2:
+            a: str = field(key=True)
+            b: int
+            t: datetime = field(timestamp=True)
+            transaction_time: int
+
+        @meta(owner="nikhil@fennel.ai")
+        @dataset
+        class B2:
+            a: str = field(key=True)
+            b_max: int
+            t: datetime
+
+            @pipeline
+            @inputs(A2)
+            def pipeline(cls, a: Dataset):
+                return a.groupby("a").aggregate(
+                    [
+                        Max(
+                            of="b",
+                            into_field="b_max",
+                            window="1d",
+                            default=1.91,
+                        ),
+                    ],
+                    emit=1,
+                )
+
+    assert (
+        str(e.value)
+        == """`1` is not a valid 'emit_strategy' in 'aggregate' operator. 'emit' in aggregation operator must be one of ['final', 'eager']"""
     )
 
 

--- a/fennel/gen/dataset_pb2.py
+++ b/fennel/gen/dataset_pb2.py
@@ -11,15 +11,15 @@ from google.protobuf.internal import builder as _builder
 _sym_db = _symbol_database.Default()
 
 
+from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 import fennel.gen.metadata_pb2 as metadata__pb2
 import fennel.gen.pycode_pb2 as pycode__pb2
 import fennel.gen.schema_pb2 as schema__pb2
 import fennel.gen.spec_pb2 as spec__pb2
-from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb2
 import fennel.gen.window_pb2 as window__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rdataset.proto\x12\x14\x66\x65nnel.proto.dataset\x1a\x0emetadata.proto\x1a\x0cpycode.proto\x1a\x0cschema.proto\x1a\nspec.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x0cwindow.proto\"\xe5\x03\n\x0b\x43oreDataset\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x08metadata\x18\x02 \x01(\x0b\x32\x1f.fennel.proto.metadata.Metadata\x12/\n\x08\x64sschema\x18\x03 \x01(\x0b\x32\x1d.fennel.proto.schema.DSSchema\x12*\n\x07history\x18\x04 \x01(\x0b\x32\x19.google.protobuf.Duration\x12,\n\tretention\x18\x05 \x01(\x0b\x32\x19.google.protobuf.Duration\x12L\n\x0e\x66ield_metadata\x18\x06 \x03(\x0b\x32\x34.fennel.proto.dataset.CoreDataset.FieldMetadataEntry\x12+\n\x06pycode\x18\x07 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x19\n\x11is_source_dataset\x18\x08 \x01(\x08\x12\x0f\n\x07version\x18\t \x01(\r\x12\x0c\n\x04tags\x18\n \x03(\t\x1aU\n\x12\x46ieldMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12.\n\x05value\x18\x02 \x01(\x0b\x32\x1f.fennel.proto.metadata.Metadata:\x02\x38\x01\"Q\n\x08OnDemand\x12\x1c\n\x14\x66unction_source_code\x18\x01 \x01(\t\x12\x10\n\x08\x66unction\x18\x02 \x01(\x0c\x12\x15\n\rexpires_after\x18\x03 \x01(\x03\"\xd2\x01\n\x08Pipeline\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x61taset_name\x18\x02 \x01(\t\x12\x11\n\tsignature\x18\x03 \x01(\t\x12\x31\n\x08metadata\x18\x04 \x01(\x0b\x32\x1f.fennel.proto.metadata.Metadata\x12\x1b\n\x13input_dataset_names\x18\x05 \x03(\t\x12\x12\n\nds_version\x18\x06 \x01(\r\x12+\n\x06pycode\x18\x07 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\"\xe7\x06\n\x08Operator\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07is_root\x18\x02 \x01(\x08\x12\x15\n\rpipeline_name\x18\x03 \x01(\t\x12\x14\n\x0c\x64\x61taset_name\x18\x04 \x01(\t\x12\x12\n\nds_version\x18\x14 \x01(\r\x12\x34\n\taggregate\x18\x05 \x01(\x0b\x32\x1f.fennel.proto.dataset.AggregateH\x00\x12*\n\x04join\x18\x06 \x01(\x0b\x32\x1a.fennel.proto.dataset.JoinH\x00\x12\x34\n\ttransform\x18\x07 \x01(\x0b\x32\x1f.fennel.proto.dataset.TransformH\x00\x12,\n\x05union\x18\x08 \x01(\x0b\x32\x1b.fennel.proto.dataset.UnionH\x00\x12.\n\x06\x66ilter\x18\t \x01(\x0b\x32\x1c.fennel.proto.dataset.FilterH\x00\x12\x37\n\x0b\x64\x61taset_ref\x18\n \x01(\x0b\x32 .fennel.proto.dataset.DatasetRefH\x00\x12.\n\x06rename\x18\x0c \x01(\x0b\x32\x1c.fennel.proto.dataset.RenameH\x00\x12*\n\x04\x64rop\x18\r \x01(\x0b\x32\x1a.fennel.proto.dataset.DropH\x00\x12\x30\n\x07\x65xplode\x18\x0e \x01(\x0b\x32\x1d.fennel.proto.dataset.ExplodeH\x00\x12,\n\x05\x64\x65\x64up\x18\x0f \x01(\x0b\x32\x1b.fennel.proto.dataset.DedupH\x00\x12,\n\x05\x66irst\x18\x10 \x01(\x0b\x32\x1b.fennel.proto.dataset.FirstH\x00\x12.\n\x06\x61ssign\x18\x11 \x01(\x0b\x32\x1c.fennel.proto.dataset.AssignH\x00\x12\x32\n\x08\x64ropnull\x18\x12 \x01(\x0b\x32\x1e.fennel.proto.dataset.DropnullH\x00\x12:\n\x06window\x18\x13 \x01(\x0b\x32(.fennel.proto.dataset.WindowOperatorKindH\x00\x12.\n\x06latest\x18\x15 \x01(\x0b\x32\x1c.fennel.proto.dataset.LatestH\x00\x12\x0c\n\x04name\x18\x0b \x01(\tB\x06\n\x04kind\"\x8c\x01\n\tAggregate\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0c\n\x04keys\x18\x02 \x03(\t\x12)\n\x05specs\x18\x03 \x03(\x0b\x32\x1a.fennel.proto.spec.PreSpec\x12\x12\n\x05\x61long\x18\x05 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x0coperand_name\x18\x04 \x01(\tB\x08\n\x06_along\"\xa2\x03\n\x04Join\x12\x16\n\x0elhs_operand_id\x18\x01 \x01(\t\x12\x1c\n\x14rhs_dsref_operand_id\x18\x02 \x01(\t\x12.\n\x02on\x18\x03 \x03(\x0b\x32\".fennel.proto.dataset.Join.OnEntry\x12\x32\n\nwithin_low\x18\x06 \x01(\x0b\x32\x19.google.protobuf.DurationH\x00\x88\x01\x01\x12\x33\n\x0bwithin_high\x18\x07 \x01(\x0b\x32\x19.google.protobuf.DurationH\x01\x88\x01\x01\x12\x18\n\x10lhs_operand_name\x18\x04 \x01(\t\x12\x1e\n\x16rhs_dsref_operand_name\x18\x05 \x01(\t\x12+\n\x03how\x18\x08 \x01(\x0e\x32\x1e.fennel.proto.dataset.Join.How\x1a)\n\x07OnEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1a\n\x03How\x12\x08\n\x04Left\x10\x00\x12\t\n\x05Inner\x10\x01\x42\r\n\x0b_within_lowB\x0e\n\x0c_within_high\"\xed\x01\n\tTransform\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12;\n\x06schema\x18\x02 \x03(\x0b\x32+.fennel.proto.dataset.Transform.SchemaEntry\x12+\n\x06pycode\x18\x03 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x14\n\x0coperand_name\x18\x04 \x01(\t\x1aL\n\x0bSchemaEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.fennel.proto.schema.DataType:\x02\x38\x01\"_\n\x06\x46ilter\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12+\n\x06pycode\x18\x02 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"\xa8\x01\n\x06\x41ssign\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12+\n\x06pycode\x18\x02 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x13\n\x0b\x63olumn_name\x18\x03 \x01(\t\x12\x32\n\x0boutput_type\x18\x04 \x01(\x0b\x32\x1d.fennel.proto.schema.DataType\x12\x14\n\x0coperand_name\x18\x05 \x01(\t\"E\n\x08\x44ropnull\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"B\n\x04\x44rop\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x10\n\x08\x64ropcols\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"\xa5\x01\n\x06Rename\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12?\n\ncolumn_map\x18\x02 \x03(\x0b\x32+.fennel.proto.dataset.Rename.ColumnMapEntry\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\x1a\x30\n\x0e\x43olumnMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"3\n\x05Union\x12\x13\n\x0boperand_ids\x18\x01 \x03(\t\x12\x15\n\roperand_names\x18\x02 \x03(\t\"B\n\x05\x44\x65\x64up\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"D\n\x07\x45xplode\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"=\n\x05\x46irst\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\n\n\x02\x62y\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\">\n\x06Latest\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\n\n\x02\x62y\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"\xcb\x01\n\x12WindowOperatorKind\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x30\n\x0bwindow_type\x18\x02 \x01(\x0b\x32\x1b.fennel.proto.window.Window\x12\n\n\x02\x62y\x18\x03 \x03(\t\x12\r\n\x05\x66ield\x18\x04 \x01(\t\x12\x32\n\x07summary\x18\x06 \x01(\x0b\x32\x1c.fennel.proto.window.SummaryH\x00\x88\x01\x01\x12\x14\n\x0coperand_name\x18\x05 \x01(\tB\n\n\x08_summary\",\n\nDatasetRef\x12\x1e\n\x16referring_dataset_name\x18\x01 \x01(\t\"\x80\x02\n\x08\x44\x61taflow\x12\x16\n\x0c\x64\x61taset_name\x18\x01 \x01(\tH\x00\x12L\n\x11pipeline_dataflow\x18\x02 \x01(\x0b\x32/.fennel.proto.dataset.Dataflow.PipelineDataflowH\x00\x12\x0c\n\x04tags\x18\x03 \x03(\t\x1ax\n\x10PipelineDataflow\x12\x14\n\x0c\x64\x61taset_name\x18\x01 \x01(\t\x12\x15\n\rpipeline_name\x18\x02 \x01(\t\x12\x37\n\x0finput_dataflows\x18\x03 \x03(\x0b\x32\x1e.fennel.proto.dataset.DataflowB\x06\n\x04kind\"\x9c\x01\n\x10PipelineLineages\x12\x14\n\x0c\x64\x61taset_name\x18\x01 \x01(\t\x12\x15\n\rpipeline_name\x18\x02 \x01(\t\x12=\n\x0einput_datasets\x18\x03 \x03(\x0b\x32%.fennel.proto.dataset.DatasetLineages\x12\x0e\n\x06\x61\x63tive\x18\x04 \x01(\x08\x12\x0c\n\x04tags\x18\x05 \x03(\t\"\\\n\x17\x44\x61tasetPipelineLineages\x12\x41\n\x11pipeline_lineages\x18\x02 \x03(\x0b\x32&.fennel.proto.dataset.PipelineLineages\"\x8b\x01\n\x0f\x44\x61tasetLineages\x12\x18\n\x0esource_dataset\x18\x01 \x01(\tH\x00\x12H\n\x0f\x64\x65rived_dataset\x18\x02 \x01(\x0b\x32-.fennel.proto.dataset.DatasetPipelineLineagesH\x00\x12\x0c\n\x04tags\x18\x03 \x03(\tB\x06\n\x04kindb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rdataset.proto\x12\x14\x66\x65nnel.proto.dataset\x1a\x1egoogle/protobuf/duration.proto\x1a\x0emetadata.proto\x1a\x0cpycode.proto\x1a\x0cschema.proto\x1a\nspec.proto\x1a\x0cwindow.proto\"\xe5\x03\n\x0b\x43oreDataset\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x08metadata\x18\x02 \x01(\x0b\x32\x1f.fennel.proto.metadata.Metadata\x12/\n\x08\x64sschema\x18\x03 \x01(\x0b\x32\x1d.fennel.proto.schema.DSSchema\x12*\n\x07history\x18\x04 \x01(\x0b\x32\x19.google.protobuf.Duration\x12,\n\tretention\x18\x05 \x01(\x0b\x32\x19.google.protobuf.Duration\x12L\n\x0e\x66ield_metadata\x18\x06 \x03(\x0b\x32\x34.fennel.proto.dataset.CoreDataset.FieldMetadataEntry\x12+\n\x06pycode\x18\x07 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x19\n\x11is_source_dataset\x18\x08 \x01(\x08\x12\x0f\n\x07version\x18\t \x01(\r\x12\x0c\n\x04tags\x18\n \x03(\t\x1aU\n\x12\x46ieldMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12.\n\x05value\x18\x02 \x01(\x0b\x32\x1f.fennel.proto.metadata.Metadata:\x02\x38\x01\"Q\n\x08OnDemand\x12\x1c\n\x14\x66unction_source_code\x18\x01 \x01(\t\x12\x10\n\x08\x66unction\x18\x02 \x01(\x0c\x12\x15\n\rexpires_after\x18\x03 \x01(\x03\"\xd2\x01\n\x08Pipeline\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x14\n\x0c\x64\x61taset_name\x18\x02 \x01(\t\x12\x11\n\tsignature\x18\x03 \x01(\t\x12\x31\n\x08metadata\x18\x04 \x01(\x0b\x32\x1f.fennel.proto.metadata.Metadata\x12\x1b\n\x13input_dataset_names\x18\x05 \x03(\t\x12\x12\n\nds_version\x18\x06 \x01(\r\x12+\n\x06pycode\x18\x07 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\"\xe7\x06\n\x08Operator\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07is_root\x18\x02 \x01(\x08\x12\x15\n\rpipeline_name\x18\x03 \x01(\t\x12\x14\n\x0c\x64\x61taset_name\x18\x04 \x01(\t\x12\x12\n\nds_version\x18\x14 \x01(\r\x12\x34\n\taggregate\x18\x05 \x01(\x0b\x32\x1f.fennel.proto.dataset.AggregateH\x00\x12*\n\x04join\x18\x06 \x01(\x0b\x32\x1a.fennel.proto.dataset.JoinH\x00\x12\x34\n\ttransform\x18\x07 \x01(\x0b\x32\x1f.fennel.proto.dataset.TransformH\x00\x12,\n\x05union\x18\x08 \x01(\x0b\x32\x1b.fennel.proto.dataset.UnionH\x00\x12.\n\x06\x66ilter\x18\t \x01(\x0b\x32\x1c.fennel.proto.dataset.FilterH\x00\x12\x37\n\x0b\x64\x61taset_ref\x18\n \x01(\x0b\x32 .fennel.proto.dataset.DatasetRefH\x00\x12.\n\x06rename\x18\x0c \x01(\x0b\x32\x1c.fennel.proto.dataset.RenameH\x00\x12*\n\x04\x64rop\x18\r \x01(\x0b\x32\x1a.fennel.proto.dataset.DropH\x00\x12\x30\n\x07\x65xplode\x18\x0e \x01(\x0b\x32\x1d.fennel.proto.dataset.ExplodeH\x00\x12,\n\x05\x64\x65\x64up\x18\x0f \x01(\x0b\x32\x1b.fennel.proto.dataset.DedupH\x00\x12,\n\x05\x66irst\x18\x10 \x01(\x0b\x32\x1b.fennel.proto.dataset.FirstH\x00\x12.\n\x06\x61ssign\x18\x11 \x01(\x0b\x32\x1c.fennel.proto.dataset.AssignH\x00\x12\x32\n\x08\x64ropnull\x18\x12 \x01(\x0b\x32\x1e.fennel.proto.dataset.DropnullH\x00\x12:\n\x06window\x18\x13 \x01(\x0b\x32(.fennel.proto.dataset.WindowOperatorKindH\x00\x12.\n\x06latest\x18\x15 \x01(\x0b\x32\x1c.fennel.proto.dataset.LatestH\x00\x12\x0c\n\x04name\x18\x0b \x01(\tB\x06\n\x04kind\"\xef\x01\n\tAggregate\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0c\n\x04keys\x18\x02 \x03(\t\x12)\n\x05specs\x18\x03 \x03(\x0b\x32\x1a.fennel.proto.spec.PreSpec\x12\x12\n\x05\x61long\x18\x05 \x01(\tH\x00\x88\x01\x01\x12?\n\remit_strategy\x18\x06 \x01(\x0e\x32(.fennel.proto.dataset.Aggregate.Emission\x12\x14\n\x0coperand_name\x18\x04 \x01(\t\" \n\x08\x45mission\x12\t\n\x05\x46inal\x10\x00\x12\t\n\x05\x45\x61ger\x10\x01\x42\x08\n\x06_along\"\xa2\x03\n\x04Join\x12\x16\n\x0elhs_operand_id\x18\x01 \x01(\t\x12\x1c\n\x14rhs_dsref_operand_id\x18\x02 \x01(\t\x12.\n\x02on\x18\x03 \x03(\x0b\x32\".fennel.proto.dataset.Join.OnEntry\x12\x32\n\nwithin_low\x18\x06 \x01(\x0b\x32\x19.google.protobuf.DurationH\x00\x88\x01\x01\x12\x33\n\x0bwithin_high\x18\x07 \x01(\x0b\x32\x19.google.protobuf.DurationH\x01\x88\x01\x01\x12\x18\n\x10lhs_operand_name\x18\x04 \x01(\t\x12\x1e\n\x16rhs_dsref_operand_name\x18\x05 \x01(\t\x12+\n\x03how\x18\x08 \x01(\x0e\x32\x1e.fennel.proto.dataset.Join.How\x1a)\n\x07OnEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1a\n\x03How\x12\x08\n\x04Left\x10\x00\x12\t\n\x05Inner\x10\x01\x42\r\n\x0b_within_lowB\x0e\n\x0c_within_high\"\xed\x01\n\tTransform\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12;\n\x06schema\x18\x02 \x03(\x0b\x32+.fennel.proto.dataset.Transform.SchemaEntry\x12+\n\x06pycode\x18\x03 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x14\n\x0coperand_name\x18\x04 \x01(\t\x1aL\n\x0bSchemaEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.fennel.proto.schema.DataType:\x02\x38\x01\"_\n\x06\x46ilter\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12+\n\x06pycode\x18\x02 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"\xa8\x01\n\x06\x41ssign\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12+\n\x06pycode\x18\x02 \x01(\x0b\x32\x1b.fennel.proto.pycode.PyCode\x12\x13\n\x0b\x63olumn_name\x18\x03 \x01(\t\x12\x32\n\x0boutput_type\x18\x04 \x01(\x0b\x32\x1d.fennel.proto.schema.DataType\x12\x14\n\x0coperand_name\x18\x05 \x01(\t\"E\n\x08\x44ropnull\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"B\n\x04\x44rop\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x10\n\x08\x64ropcols\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"\xa5\x01\n\x06Rename\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12?\n\ncolumn_map\x18\x02 \x03(\x0b\x32+.fennel.proto.dataset.Rename.ColumnMapEntry\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\x1a\x30\n\x0e\x43olumnMapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"3\n\x05Union\x12\x13\n\x0boperand_ids\x18\x01 \x03(\t\x12\x15\n\roperand_names\x18\x02 \x03(\t\"B\n\x05\x44\x65\x64up\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"D\n\x07\x45xplode\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x0f\n\x07\x63olumns\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"=\n\x05\x46irst\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\n\n\x02\x62y\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\">\n\x06Latest\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\n\n\x02\x62y\x18\x02 \x03(\t\x12\x14\n\x0coperand_name\x18\x03 \x01(\t\"\xcb\x01\n\x12WindowOperatorKind\x12\x12\n\noperand_id\x18\x01 \x01(\t\x12\x30\n\x0bwindow_type\x18\x02 \x01(\x0b\x32\x1b.fennel.proto.window.Window\x12\n\n\x02\x62y\x18\x03 \x03(\t\x12\r\n\x05\x66ield\x18\x04 \x01(\t\x12\x32\n\x07summary\x18\x06 \x01(\x0b\x32\x1c.fennel.proto.window.SummaryH\x00\x88\x01\x01\x12\x14\n\x0coperand_name\x18\x05 \x01(\tB\n\n\x08_summary\",\n\nDatasetRef\x12\x1e\n\x16referring_dataset_name\x18\x01 \x01(\t\"\x80\x02\n\x08\x44\x61taflow\x12\x16\n\x0c\x64\x61taset_name\x18\x01 \x01(\tH\x00\x12L\n\x11pipeline_dataflow\x18\x02 \x01(\x0b\x32/.fennel.proto.dataset.Dataflow.PipelineDataflowH\x00\x12\x0c\n\x04tags\x18\x03 \x03(\t\x1ax\n\x10PipelineDataflow\x12\x14\n\x0c\x64\x61taset_name\x18\x01 \x01(\t\x12\x15\n\rpipeline_name\x18\x02 \x01(\t\x12\x37\n\x0finput_dataflows\x18\x03 \x03(\x0b\x32\x1e.fennel.proto.dataset.DataflowB\x06\n\x04kind\"\x9c\x01\n\x10PipelineLineages\x12\x14\n\x0c\x64\x61taset_name\x18\x01 \x01(\t\x12\x15\n\rpipeline_name\x18\x02 \x01(\t\x12=\n\x0einput_datasets\x18\x03 \x03(\x0b\x32%.fennel.proto.dataset.DatasetLineages\x12\x0e\n\x06\x61\x63tive\x18\x04 \x01(\x08\x12\x0c\n\x04tags\x18\x05 \x03(\t\"\\\n\x17\x44\x61tasetPipelineLineages\x12\x41\n\x11pipeline_lineages\x18\x02 \x03(\x0b\x32&.fennel.proto.dataset.PipelineLineages\"\x8b\x01\n\x0f\x44\x61tasetLineages\x12\x18\n\x0esource_dataset\x18\x01 \x01(\tH\x00\x12H\n\x0f\x64\x65rived_dataset\x18\x02 \x01(\x0b\x32-.fennel.proto.dataset.DatasetPipelineLineagesH\x00\x12\x0c\n\x04tags\x18\x03 \x03(\tB\x06\n\x04kindb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -45,51 +45,53 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_OPERATOR']._serialized_start=926
   _globals['_OPERATOR']._serialized_end=1797
   _globals['_AGGREGATE']._serialized_start=1800
-  _globals['_AGGREGATE']._serialized_end=1940
-  _globals['_JOIN']._serialized_start=1943
-  _globals['_JOIN']._serialized_end=2361
-  _globals['_JOIN_ONENTRY']._serialized_start=2261
-  _globals['_JOIN_ONENTRY']._serialized_end=2302
-  _globals['_JOIN_HOW']._serialized_start=2304
-  _globals['_JOIN_HOW']._serialized_end=2330
-  _globals['_TRANSFORM']._serialized_start=2364
-  _globals['_TRANSFORM']._serialized_end=2601
-  _globals['_TRANSFORM_SCHEMAENTRY']._serialized_start=2525
-  _globals['_TRANSFORM_SCHEMAENTRY']._serialized_end=2601
-  _globals['_FILTER']._serialized_start=2603
-  _globals['_FILTER']._serialized_end=2698
-  _globals['_ASSIGN']._serialized_start=2701
-  _globals['_ASSIGN']._serialized_end=2869
-  _globals['_DROPNULL']._serialized_start=2871
-  _globals['_DROPNULL']._serialized_end=2940
-  _globals['_DROP']._serialized_start=2942
-  _globals['_DROP']._serialized_end=3008
-  _globals['_RENAME']._serialized_start=3011
-  _globals['_RENAME']._serialized_end=3176
-  _globals['_RENAME_COLUMNMAPENTRY']._serialized_start=3128
-  _globals['_RENAME_COLUMNMAPENTRY']._serialized_end=3176
-  _globals['_UNION']._serialized_start=3178
-  _globals['_UNION']._serialized_end=3229
-  _globals['_DEDUP']._serialized_start=3231
-  _globals['_DEDUP']._serialized_end=3297
-  _globals['_EXPLODE']._serialized_start=3299
-  _globals['_EXPLODE']._serialized_end=3367
-  _globals['_FIRST']._serialized_start=3369
-  _globals['_FIRST']._serialized_end=3430
-  _globals['_LATEST']._serialized_start=3432
-  _globals['_LATEST']._serialized_end=3494
-  _globals['_WINDOWOPERATORKIND']._serialized_start=3497
-  _globals['_WINDOWOPERATORKIND']._serialized_end=3700
-  _globals['_DATASETREF']._serialized_start=3702
-  _globals['_DATASETREF']._serialized_end=3746
-  _globals['_DATAFLOW']._serialized_start=3749
-  _globals['_DATAFLOW']._serialized_end=4005
-  _globals['_DATAFLOW_PIPELINEDATAFLOW']._serialized_start=3877
-  _globals['_DATAFLOW_PIPELINEDATAFLOW']._serialized_end=3997
-  _globals['_PIPELINELINEAGES']._serialized_start=4008
-  _globals['_PIPELINELINEAGES']._serialized_end=4164
-  _globals['_DATASETPIPELINELINEAGES']._serialized_start=4166
-  _globals['_DATASETPIPELINELINEAGES']._serialized_end=4258
-  _globals['_DATASETLINEAGES']._serialized_start=4261
-  _globals['_DATASETLINEAGES']._serialized_end=4400
+  _globals['_AGGREGATE']._serialized_end=2039
+  _globals['_AGGREGATE_EMISSION']._serialized_start=1997
+  _globals['_AGGREGATE_EMISSION']._serialized_end=2029
+  _globals['_JOIN']._serialized_start=2042
+  _globals['_JOIN']._serialized_end=2460
+  _globals['_JOIN_ONENTRY']._serialized_start=2360
+  _globals['_JOIN_ONENTRY']._serialized_end=2401
+  _globals['_JOIN_HOW']._serialized_start=2403
+  _globals['_JOIN_HOW']._serialized_end=2429
+  _globals['_TRANSFORM']._serialized_start=2463
+  _globals['_TRANSFORM']._serialized_end=2700
+  _globals['_TRANSFORM_SCHEMAENTRY']._serialized_start=2624
+  _globals['_TRANSFORM_SCHEMAENTRY']._serialized_end=2700
+  _globals['_FILTER']._serialized_start=2702
+  _globals['_FILTER']._serialized_end=2797
+  _globals['_ASSIGN']._serialized_start=2800
+  _globals['_ASSIGN']._serialized_end=2968
+  _globals['_DROPNULL']._serialized_start=2970
+  _globals['_DROPNULL']._serialized_end=3039
+  _globals['_DROP']._serialized_start=3041
+  _globals['_DROP']._serialized_end=3107
+  _globals['_RENAME']._serialized_start=3110
+  _globals['_RENAME']._serialized_end=3275
+  _globals['_RENAME_COLUMNMAPENTRY']._serialized_start=3227
+  _globals['_RENAME_COLUMNMAPENTRY']._serialized_end=3275
+  _globals['_UNION']._serialized_start=3277
+  _globals['_UNION']._serialized_end=3328
+  _globals['_DEDUP']._serialized_start=3330
+  _globals['_DEDUP']._serialized_end=3396
+  _globals['_EXPLODE']._serialized_start=3398
+  _globals['_EXPLODE']._serialized_end=3466
+  _globals['_FIRST']._serialized_start=3468
+  _globals['_FIRST']._serialized_end=3529
+  _globals['_LATEST']._serialized_start=3531
+  _globals['_LATEST']._serialized_end=3593
+  _globals['_WINDOWOPERATORKIND']._serialized_start=3596
+  _globals['_WINDOWOPERATORKIND']._serialized_end=3799
+  _globals['_DATASETREF']._serialized_start=3801
+  _globals['_DATASETREF']._serialized_end=3845
+  _globals['_DATAFLOW']._serialized_start=3848
+  _globals['_DATAFLOW']._serialized_end=4104
+  _globals['_DATAFLOW_PIPELINEDATAFLOW']._serialized_start=3976
+  _globals['_DATAFLOW_PIPELINEDATAFLOW']._serialized_end=4096
+  _globals['_PIPELINELINEAGES']._serialized_start=4107
+  _globals['_PIPELINELINEAGES']._serialized_end=4263
+  _globals['_DATASETPIPELINELINEAGES']._serialized_start=4265
+  _globals['_DATASETPIPELINELINEAGES']._serialized_end=4357
+  _globals['_DATASETLINEAGES']._serialized_start=4360
+  _globals['_DATASETLINEAGES']._serialized_end=4499
 # @@protoc_insertion_point(module_scope)

--- a/fennel/gen/dataset_pb2.pyi
+++ b/fennel/gen/dataset_pb2.pyi
@@ -268,10 +268,24 @@ global___Operator = Operator
 class Aggregate(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
 
+    class _Emission:
+        ValueType = typing.NewType("ValueType", builtins.int)
+        V: typing_extensions.TypeAlias = ValueType
+
+    class _EmissionEnumTypeWrapper(google.protobuf.internal.enum_type_wrapper._EnumTypeWrapper[Aggregate._Emission.ValueType], builtins.type):
+        DESCRIPTOR: google.protobuf.descriptor.EnumDescriptor
+        Final: Aggregate._Emission.ValueType  # 0
+        Eager: Aggregate._Emission.ValueType  # 1
+
+    class Emission(_Emission, metaclass=_EmissionEnumTypeWrapper): ...
+    Final: Aggregate.Emission.ValueType  # 0
+    Eager: Aggregate.Emission.ValueType  # 1
+
     OPERAND_ID_FIELD_NUMBER: builtins.int
     KEYS_FIELD_NUMBER: builtins.int
     SPECS_FIELD_NUMBER: builtins.int
     ALONG_FIELD_NUMBER: builtins.int
+    EMIT_STRATEGY_FIELD_NUMBER: builtins.int
     OPERAND_NAME_FIELD_NUMBER: builtins.int
     operand_id: builtins.str
     @property
@@ -279,6 +293,7 @@ class Aggregate(google.protobuf.message.Message):
     @property
     def specs(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[spec_pb2.PreSpec]: ...
     along: builtins.str
+    emit_strategy: global___Aggregate.Emission.ValueType
     operand_name: builtins.str
     """NOTE: FOLLOWING PROPERTIES ARE SET BY THE SERVER AND WILL BE IGNORED BY
     THE CLIENT
@@ -290,10 +305,11 @@ class Aggregate(google.protobuf.message.Message):
         keys: collections.abc.Iterable[builtins.str] | None = ...,
         specs: collections.abc.Iterable[spec_pb2.PreSpec] | None = ...,
         along: builtins.str | None = ...,
+        emit_strategy: global___Aggregate.Emission.ValueType = ...,
         operand_name: builtins.str = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["_along", b"_along", "along", b"along"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["_along", b"_along", "along", b"along", "keys", b"keys", "operand_id", b"operand_id", "operand_name", b"operand_name", "specs", b"specs"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_along", b"_along", "along", b"along", "emit_strategy", b"emit_strategy", "keys", b"keys", "operand_id", b"operand_id", "operand_name", b"operand_name", "specs", b"specs"]) -> None: ...
     def WhichOneof(self, oneof_group: typing_extensions.Literal["_along", b"_along"]) -> typing_extensions.Literal["along"] | None: ...
 
 global___Aggregate = Aggregate

--- a/fennel/internal_lib/to_proto/serializer.py
+++ b/fennel/internal_lib/to_proto/serializer.py
@@ -15,7 +15,7 @@ import fennel.gen.dataset_pb2 as proto
 import fennel.gen.pycode_pb2 as pycode_proto
 import fennel.gen.window_pb2 as window_proto
 from fennel.datasets import Dataset, Pipeline, Visitor
-from fennel.datasets.datasets import WindowType
+from fennel.datasets.datasets import WindowType, EmitStrategy
 from fennel.internal_lib.duration import (
     duration_to_timedelta,
 )
@@ -217,6 +217,10 @@ def {new_entry_point}(df: pd.DataFrame) -> pd.DataFrame:
         )
 
     def visitAggregate(self, obj):
+        if obj.emit_strategy == EmitStrategy.Final:
+            emit_strategy = proto.Aggregate.Final
+        else:
+            emit_strategy = proto.Aggregate.Eager
         return proto.Operator(
             id=obj.signature(),
             is_root=obj == self.terminal_node,
@@ -228,6 +232,7 @@ def {new_entry_point}(df: pd.DataFrame) -> pd.DataFrame:
                 keys=obj.keys,
                 specs=[agg.to_proto() for agg in obj.aggregates],
                 along=obj.along,
+                emit_strategy=emit_strategy,
             ),
         )
 

--- a/fennel/testing/data_engine.py
+++ b/fennel/testing/data_engine.py
@@ -160,7 +160,6 @@ class DataEngine(object):
         # If we haven't seen any values for this dataset, return an empty df with the right schema.
         if (
             not isinstance(self.datasets[dataset_name].data, pd.DataFrame)
-            and not self.datasets[dataset_name].aggregated_datasets
         ):
             return self.datasets[dataset_name].empty_df()
 
@@ -529,6 +528,13 @@ class DataEngine(object):
         df = df.reset_index(drop=True)
         return df, found
 
+    @staticmethod
+    def _make_object_hashable(obj):
+        try:
+            return str(dict(obj))
+        except:
+            return str(obj)
+
     def _as_of_lookup(
         self,
         dataset_name: str,
@@ -690,13 +696,6 @@ class DataEngine(object):
                     f"in dataset `{dataset_name}`: {str(e)}",
                 )
             if ret is None:
-                continue
-            if ret.is_aggregate:
-                # Aggregate pipelines are not logged
-                self.datasets[pipeline.dataset_name].aggregated_datasets = (
-                    ret.agg_result
-                )
-                self._filter_erase_key(dataset_name)
                 continue
 
             # Recursively log the output of the pipeline to the datasets

--- a/fennel/testing/data_engine.py
+++ b/fennel/testing/data_engine.py
@@ -158,9 +158,7 @@ class DataEngine(object):
             raise ValueError(f"Dataset `{dataset_name}` not found")
 
         # If we haven't seen any values for this dataset, return an empty df with the right schema.
-        if (
-            not isinstance(self.datasets[dataset_name].data, pd.DataFrame)
-        ):
+        if not isinstance(self.datasets[dataset_name].data, pd.DataFrame):
             return self.datasets[dataset_name].empty_df()
 
         if isinstance(self.datasets[dataset_name].data, pd.DataFrame):
@@ -527,13 +525,6 @@ class DataEngine(object):
             df = df[fields]
         df = df.reset_index(drop=True)
         return df, found
-
-    @staticmethod
-    def _make_object_hashable(obj):
-        try:
-            return str(dict(obj))
-        except:
-            return str(obj)
 
     def _as_of_lookup(
         self,

--- a/fennel/testing/execute_aggregation.py
+++ b/fennel/testing/execute_aggregation.py
@@ -445,6 +445,9 @@ def get_aggregated_df(
                     )
             result_vals.append(state[key].add_val_to_state(val))
 
+    if hasattr(aggregate, 'default'):
+        result_vals = [x if x is not None else aggregate.default for x in result_vals]
+
     df[aggregate.into_field] = result_vals
     if aggregate.into_field != of_field:
         df.drop(of_field, inplace=True, axis=1)

--- a/fennel/testing/executor.py
+++ b/fennel/testing/executor.py
@@ -19,6 +19,7 @@ from fennel.testing.execute_aggregation import get_aggregated_df
 pd.set_option("display.max_columns", None)
 FENNEL_KEY_HASH_ROW = "__fennel_key_hash_row__"
 
+
 @dataclass
 class NodeRet:
     df: pd.DataFrame
@@ -173,14 +174,11 @@ class Executor(Visitor):
             sorted_df, input_ret.timestamp_field, input_ret.key_fields
         )
 
-    def _key_hash(
-        self, row, keys: list[str]
-    ) -> pd.DataFrame:
+    def _key_hash(self, row, keys: list[str]) -> pd.DataFrame:
         row_key_fields = []
         for key_field in keys:
             row_key_fields.append(row.loc[key_field])
         keyhash = hash(tuple(row_key_fields))
-        print(keyhash)
         return keyhash
 
     def visitAggregate(self, obj):
@@ -191,48 +189,50 @@ class Executor(Visitor):
         if obj.along is not None:
             df[input_ret.timestamp_field] = df[obj.along]
         df = df.sort_values(input_ret.timestamp_field)
-        # For aggregates the result is not a dataframe but a dictionary
-        # of fields to the dataframe that contains the aggregate values
-        # for each timestamp for that field.
         result = {}
         output_schema = obj.dsschema()
+        ts_field = input_ret.timestamp_field
         for aggregate in obj.aggregates:
             # Select the columns that are needed for the aggregate
             # and drop the rest
-            ts_field = input_ret.timestamp_field
-            fields = obj.keys + [ts_field]
-            if not isinstance(aggregate, Count) or aggregate.unique:
-                fields.append(aggregate.of)
-            filtered_df = df[fields]
+            input_keys = input_ret.key_fields
 
             result[aggregate.into_field] = get_aggregated_df(
-                filtered_df,
+                df,
                 aggregate,
                 ts_field,
+                input_keys,
                 obj.keys,
                 output_schema.values[aggregate.into_field],
-            ).applymap(lambda x: (True, x))
+            )
 
-        agg_dfs = list(result.values())
-        total_df = agg_dfs[0]
-        for df in agg_dfs[1:]:
-            total_df = pd.merge(total_df, df, how="outer", on=obj.keys + [ts_field])
-
-        total_df[FENNEL_KEY_HASH_ROW] = total_df.apply(lambda row: self._key_hash(row, obj.keys), axis=1)
-        total_df = total_df.sort_values(by=[FENNEL_KEY_HASH_ROW, ts_field]).reset_index(drop=True)
-        for i, row in total_df.iterrows():
-            if i == 0 or row.loc[FENNEL_KEY_HASH_ROW] != total_df.iloc[i-1].loc[FENNEL_KEY_HASH_ROW]:
-                continue
-            for aggregate in obj.aggregates:
-                if pd.isna(row.loc[aggregate.into_field]):
-                    row.loc[aggregate.into_field] = total_df.iloc[i - 1][aggregate.into_field]
-            total_df.iloc[i] = row
-        total_df = total_df.sort_values(by=[ts_field]).drop(FENNEL_KEY_HASH_ROW, axis=1).applymap(lambda x: x[1])
-
-        total_df = _cast_primitive_dtype_columns(total_df, obj)
-        return NodeRet(
-            total_df, input_ret.timestamp_field, obj.keys
-        )
+        key_dfs = pd.DataFrame()
+        required_fields = obj.keys + [input_ret.timestamp_field]
+        # Collect all timestamps across all columns
+        for data in result.values():  # type: ignore
+            subset_df = data[required_fields]
+            key_dfs = pd.concat([key_dfs, subset_df], ignore_index=True)
+            key_dfs.drop_duplicates(inplace=True)
+        # Sort key_dfs by timestamp
+        key_dfs.sort_values(ts_field, inplace=True)
+        # Find the values for all columns as of the timestamp in key_dfs
+        extrapolated_dfs = []
+        for col, data in result.items():  # type: ignore
+            print(key_dfs.dtypes)
+            print(data.dtypes)
+            df = pd.merge_asof(
+                left=key_dfs,
+                right=data,
+                on=ts_field,
+                by=obj.keys,
+                direction="backward",
+                suffixes=("", "_right"),
+            )
+            extrapolated_dfs.append(df)
+        # Merge all the extrapolated dfs, column wise and drop duplicate columns
+        df = pd.concat(extrapolated_dfs, axis=1)
+        df = df.loc[:, ~df.columns.duplicated()]
+        return NodeRet(df, input_ret.timestamp_field, obj.keys)
 
     def visitJoin(self, obj) -> Optional[NodeRet]:
         input_ret = self.visit(obj.node)

--- a/fennel/testing/test_execute_aggregation.py
+++ b/fennel/testing/test_execute_aggregation.py
@@ -101,7 +101,7 @@ def test_min_state():
     assert state.get_val() == 3
     assert state.del_val_from_state(3) == 3
     assert state.get_val() == 3
-    assert state.del_val_from_state(3) is None
+    assert state.del_val_from_state(3) is 3.0
 
 
 def test_max_state():
@@ -116,7 +116,7 @@ def test_max_state():
     assert state.get_val() == 3
     assert state.del_val_from_state(3) == 3
     assert state.get_val() == 3
-    assert state.del_val_from_state(3) is None
+    assert state.del_val_from_state(3) == 3.0
 
 
 def test_min_forever_state():


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f6056c24f9d8c6108c89551d4728e6b828430647  | 
|--------|

### Summary:
This PR introduces an 'emit strategy' for the 'aggregate' operator in the Mock Client, removes the requirement for the 'aggregate' operator to be a terminal operator, and includes modifications to several files and test cases.

**Key points**:
- Introduced 'emit strategy' for 'aggregate' operator in Mock Client.
- Removed requirement for 'aggregate' operator to be a terminal operator.
- 'emit strategy' can be 'close' or 'update'.
- Modified several files including 'fennel/client_tests/test_dataset.py', 'fennel/datasets/datasets.py', 'fennel/datasets/test_dataset.py', 'fennel/gen/dataset_pb2.pyi', 'fennel/internal_lib/to_proto/serializer.py', and 'fennel/testing/executor.py'.
- Modified test cases to accommodate these changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
