### PR TITLE
Add support for indirections in preproc ref type

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -231,6 +231,7 @@ hudi
 hyperloglog
 iam
 incrementing
+indirections
 init
 initializer
 interop

--- a/docs/pages/api-reference/decorators/source.md
+++ b/docs/pages/api-reference/decorators/source.md
@@ -92,10 +92,17 @@ As of right now, there are two kinds of values of preproc:
 * `ref: Ref`: written as `ref(str)` and means that the column denoted
   by the key of this value is aliased to another column in the sourced data. This
   is useful, for instance, when you want to rename columns while bringing them
-  to Fennel. 
+  to Fennel. With this, you can also perform indirections of kind A[B][C] and 
+  renaming them while brining to fennel.
 
 * `Any`: means that the column denoted by the key of this value should be given
   a constant value.
+
+:::info
+Fennel supports preproc ref(str) values of type A[B][C] only for the JSON format.
+If you have data in other format, please reach out to Fennel support.
+:::
+
 </Expandable>
 
 

--- a/docs/pages/api-reference/decorators/source.md
+++ b/docs/pages/api-reference/decorators/source.md
@@ -93,7 +93,7 @@ As of right now, there are two kinds of values of preproc:
   by the key of this value is aliased to another column in the sourced data. This
   is useful, for instance, when you want to rename columns while bringing them
   to Fennel. With this, you can also perform indirections of kind A[B][C] and 
-  renaming them while brining to fennel.
+  renaming them while bringing to fennel.
 
 * `Any`: means that the column denoted by the key of this value should be given
   a constant value.

--- a/docs/pages/api-reference/decorators/source.md
+++ b/docs/pages/api-reference/decorators/source.md
@@ -93,14 +93,15 @@ As of right now, there are two kinds of values of preproc:
   by the key of this value is aliased to another column in the sourced data. This
   is useful, for instance, when you want to rename columns while bringing them
   to Fennel. With this, you can also perform indirections of kind A[B][C] and 
-  renaming them while bringing to fennel.
+  rename them while bringing to fennel.
 
 * `Any`: means that the column denoted by the key of this value should be given
   a constant value.
 
 :::info
-Fennel supports preproc ref(str) values of type A[B][C] only for the JSON format.
-If you have data in other format, please reach out to Fennel support.
+Fennel supports preproc ref(str) values of type A[B][C] only for the JSON format and 
+A, B should be struct types. If you have data in other format or require indirection
+for other parent types apart from struct, please reach out to Fennel support.
 :::
 
 </Expandable>

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
+## [1.3.25] - 2024-05-31
+- Add support for indirections in preproc ref type
+
 ## [1.3.24] - 2024-05-28
 - Add support for hopping/tumbling/forever/session discrete window aggregation in mock. 
-
-## [1.3.23] - 2024-05-30
-- Add support for indirections in preproc ref type
 
 ## [1.3.23] - 2024-05-28
 - Add support for bytes type. 

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -2,6 +2,9 @@
 ## [1.3.24] - 2024-05-28
 - Add support for hopping/tumbling/forever/session discrete window aggregation in mock. 
 
+## [1.3.23] - 2024-05-30
+- Add support for indirections in preproc ref type
+
 ## [1.3.23] - 2024-05-28
 - Add support for bytes type. 
 

--- a/fennel/connectors/connectors.py
+++ b/fennel/connectors/connectors.py
@@ -47,7 +47,21 @@ def preproc_has_indirection(preproc: Optional[Dict[str, PreProcValue]]):
         return False
 
     for value in preproc.values():
-        if isinstance(value, Ref) and "[" in value.name:
+        if isinstance(value, Ref):
+            if len(value.name) == 0:
+                raise ValueError(
+                    "Expected column name to be non empty inside preproc ref type"
+                )
+            child_names = value.name.split("[")
+            # If there is only 1 child, it means there is no indirection
+            if len(child_names) == 1:
+                return False
+            # Last character of all the childs except the first one should be "]"
+            for idx in range(1, len(child_names)):
+                if child_names[idx][-1] != "]":
+                    raise ValueError(
+                        "Invalid preproc value of ref type, there is no closing ] for the corresponding opening ["
+                    )
             return True
     return False
 

--- a/fennel/connectors/test_connectors.py
+++ b/fennel/connectors/test_connectors.py
@@ -2029,3 +2029,48 @@ def test_bounded_source_with_idleness():
     assert extdb_request == expected_extdb_request, error_message(
         extdb_request, expected_extdb_request
     )
+
+
+def test_valid_preproc_value():
+    # Preproc value of type A[B][C] can be only set for data in JSON format
+    source(
+        s3.bucket(
+            bucket_name="all_ratings", prefix="prod/apac/", format="json"
+        ),
+        every="1h",
+        disorder="14d",
+        cdc="native",
+        preproc={"C": ref("A[B][C]"), "D": "A[B][C]"},
+    )
+
+    source(
+        s3.bucket(
+            bucket_name="all_ratings", prefix="prod/apac/", format="parquet"
+        ),
+        every="1h",
+        disorder="14d",
+        cdc="append",
+        preproc={"C": "A[B][C]", "D": "A[B][C]"},
+    )
+
+    source(
+        kafka.topic(topic="topic", format="Avro"),
+        every="1h",
+        disorder="14d",
+        cdc="debezium",
+        preproc={"C": "A[B][C]", "D": "A[B][C]"},
+    )
+    source(
+        kafka.topic(topic="topic"),
+        every="1h",
+        disorder="14d",
+        cdc="debezium",
+        preproc={"C": ref("A[B][C]"), "D": "A[B][C]"},
+    )
+    source(
+        kafka.topic(topic="topic", format="json"),
+        every="1h",
+        disorder="14d",
+        cdc="debezium",
+        preproc={"C": ref("A[B][C]"), "D": "A[B][C]"},
+    )

--- a/fennel/connectors/test_invalid_connectors.py
+++ b/fennel/connectors/test_invalid_connectors.py
@@ -637,6 +637,38 @@ def test_invalid_bounded_and_idleness():
 
 
 def test_invalid_preproc_value():
+    # Preproc value of "" cannot be set
+    with pytest.raises(ValueError) as e:
+        source(
+            s3.bucket(
+                bucket_name="all_ratings", prefix="prod/apac/", format="json"
+            ),
+            every="1h",
+            disorder="14d",
+            cdc="append",
+            preproc={"C": ref("")},
+        )
+    assert (
+        "Expected column name to be non empty inside preproc ref type"
+        == str(e.value)
+    )
+
+    # Preproc value of "A[B[C]" cannot be set
+    with pytest.raises(ValueError) as e:
+        source(
+            s3.bucket(
+                bucket_name="all_ratings", prefix="prod/apac/", format="json"
+            ),
+            every="1h",
+            disorder="14d",
+            cdc="append",
+            preproc={"C": ref("A[B[C]")},
+        )
+    assert (
+        "Invalid preproc value of ref type, there is no closing ] for the corresponding opening ["
+        == str(e.value)
+    )
+
     # Preproc value of type A[B][C] cannot be set for data other than JSON format
     with pytest.raises(ValueError) as e:
         source(

--- a/fennel/connectors/test_invalid_connectors.py
+++ b/fennel/connectors/test_invalid_connectors.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
+from fennel.connectors.connectors import ref
 import pytest
 
 from fennel.connectors import (
@@ -631,5 +632,37 @@ def test_invalid_bounded_and_idleness():
 
     assert (
         "idleness parameter should not be passed when bounded is set as False"
+        == str(e.value)
+    )
+
+
+def test_invalid_preproc_value():
+    # Preproc value of type A[B][C] cannot be set for data other than JSON format
+    with pytest.raises(ValueError) as e:
+        source(
+            s3.bucket(
+                bucket_name="all_ratings", prefix="prod/apac/", format="delta"
+            ),
+            every="1h",
+            disorder="14d",
+            cdc="native",
+            preproc={"C": ref("A[B][C]"), "D": "A[B][C]"},
+        )
+    assert (
+        "Preproc of type ref('A[B][C]') is applicable only for data in JSON format"
+        == str(e.value)
+    )
+
+    # Preproc value of type A[B][C] cannot be set for data other than JSON format
+    with pytest.raises(ValueError) as e:
+        source(
+            kafka.topic(topic="topic", format="Avro"),
+            every="1h",
+            disorder="14d",
+            cdc="debezium",
+            preproc={"C": ref("A[B][C]"), "D": "A[B][C]"},
+        )
+    assert (
+        "Preproc of type ref('A[B][C]') is applicable only for data in JSON format"
         == str(e.value)
     )


### PR DESCRIPTION
- Add validation around preproc of type A[B][C] to support only JSON format
- Updated the documentation accordingly
 
<img width="464" alt="Screenshot 2024-05-31 at 5 05 07 PM" src="https://github.com/fennel-ai/client/assets/20837258/70e69304-c490-4605-97e9-6acbc7fb583d">



