### PR TITLE
[FIX] Added a more robust way to getting text code for where in preproc

### DIFF
--- a/docs/examples/concepts/source.py
+++ b/docs/examples/concepts/source.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 
 from fennel.connectors import Kafka, S3, source
@@ -70,25 +71,26 @@ def test_stacked_sources_in_env(client):
 
 @mock
 def test_filter_preproc_source(client):
-    s3 = S3(name="mys3")
+    if sys.version_info >= (3, 10):
+        s3 = S3(name="mys3")
 
-    # docsnip where
-    # docsnip-highlight start
-    @source(
-        s3.bucket("data", path="*"),
-        disorder="1w",
-        cdc="append",
-        where=lambda x: x["skuid"] >= 1000,
-    )
-    # docsnip-highlight end
-    @dataset
-    class Order:
-        uid: int
-        skuid: int
-        at: datetime
+        # docsnip where
+        # docsnip-highlight start
+        @source(
+            s3.bucket("data", path="*"),
+            disorder="1w",
+            cdc="append",
+            where=lambda x: x["skuid"] >= 1000,
+        )
+        # docsnip-highlight end
+        @dataset
+        class Order:
+            uid: int
+            skuid: int
+            at: datetime
 
-    client.commit(
-        message="some commit msg",
-        datasets=[Order],
-    )
-    # /docsnip
+        client.commit(
+            message="some commit msg",
+            datasets=[Order],
+        )
+        # /docsnip

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.4.1] - 2024-07-16
+- Fixed rendering of lambda function in unformatted code.
+
 ## [1.4.0] - 2024-07-15
 - Added mock client support keyed window aggregations. 
 

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -369,6 +369,26 @@ class _Node(Generic[T]):
         return Union_(self, other)
 
 
+def get_all_operators() -> List[str]:
+    """
+    Get all the operators a user can use on a Dataset in a pipeline.
+    Returns:
+        List[str] -> List operator names in string.
+    """
+    class_dict = dict(_Node.__dict__)
+    output = []
+    for member in class_dict:
+        if "__" not in member and member not in [
+            "signature",
+            "isignature",
+            "schema",
+            "dsschema",
+            "num_out_edges",
+        ]:
+            output.append(member)
+    return output
+
+
 class Transform(_Node):
     def __init__(self, node: _Node, func: Callable, schema: Optional[Dict]):
         super().__init__()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.3.39"
+version = "1.4.1"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
1. Moved removal of decorators from regex to AST.
2. Added more robust way to getting function text of a lambda.

This PR fixes most of the issues, but there are still some formatting for which this fails.