### PR TITLE
extractor: Make embedding type hashable

### DIFF
--- a/fennel/dtypes/dtypes.py
+++ b/fennel/dtypes/dtypes.py
@@ -131,7 +131,7 @@ def struct(cls):
 # ---------------------------------------------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class _Embedding:
     dim: int
 

--- a/fennel/featuresets/featureset.py
+++ b/fennel/featuresets/featureset.py
@@ -298,7 +298,6 @@ def extractor(
                     f"Series[feature, str] or dataframe[<list of features defined in this featureset>], "
                     f"found {type(return_annotation)}"
                 )
-
         setattr(
             extractor_func,
             EXTRACTOR_ATTR,
@@ -615,6 +614,11 @@ class Featureset:
             extractor.set_inputs_from_featureset(self, feature)
             extractor.featureset = self._name
             extractor.outputs = [feature]
+            # If extractor already exists, throw an error
+            if extractor.name in [e.name for e in output]:
+                raise ValueError(
+                    f"An auto-generated extractor `{extractor.name}` already exists in the featureset `{self._name}`."
+                )
             output.append(extractor)
         return output
 

--- a/fennel/internal_lib/schema/schema.py
+++ b/fennel/internal_lib/schema/schema.py
@@ -70,7 +70,7 @@ def parse_json(annotation, json) -> Any:
                     f"Union must be of the form `Union[type, None]`, "
                     f"got `{annotation}`"
                 )
-            if json is None or pd.isna(json):
+            if json is None or (not isinstance(json, list) and pd.isna(json)):
                 return None
             return parse_json(args[0], json)
         if origin is list:

--- a/fennel/testing/query_engine.py
+++ b/fennel/testing/query_engine.py
@@ -386,7 +386,6 @@ class QueryEngine:
         results = results[extractor.derived_extractor_info.field.name]
         default_value = extractor.derived_extractor_info.default
         proto_dtype = get_datatype(extractor.derived_extractor_info.field.dtype)
-
         # Custom operations on default value for datetime and decimal type
         if proto_dtype.HasField("decimal_type"):
             if pd.notna(default_value) and not isinstance(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.4.2"
+version = "1.4.3"
+
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
Few more small fixes-
1. Allow only one autogenerated extractor for a given field ( else you have the same one with different defaults, but we only create a single extractor which overrides each other ), we can add this if required later.
2. Check pd.NA only if its not a list