### PR TITLE
Fix an integration test

### DIFF
--- a/fennel/client_tests/test_social_network.py
+++ b/fennel/client_tests/test_social_network.py
@@ -51,7 +51,7 @@ class PostInfoWithRightFields:
     category: str  # type: ignore
     post_id: int = field(key=True)
     timestamp: datetime
-    extra_field: str
+    extra_field: int
 
 
 @meta(owner="data-eng@myspace.com")


### PR DESCRIPTION
The test `test_social_network.py` fails in backend mode because of wrong
type assigned to a field. This change fixes the same.