### PR TITLE
[DEV 4629] Make schema in eval preproc explicit [CLOSED]

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.31] - 2024-09-24
+- Make schema in eval preproc explicit.
+
 ## [1.5.30] - 2024-09-24
 - Add hour, minute, second, millisecond, microsecond, day, week accessors as properties instead of methods.
 

--- a/fennel/internal_lib/to_proto/to_proto.py
+++ b/fennel/internal_lib/to_proto/to_proto.py
@@ -461,7 +461,7 @@ def _validate_source_pre_proc(
                     if isinstance(pre_proc_val.eval_type, Expr)
                     else pre_proc_val.eval_type.dtype
                 )
-                input_schema = ds.schema()
+                input_schema = {}
                 if pre_proc_val.additional_schema:
                     for name, dtype in pre_proc_val.additional_schema.items():
                         input_schema[name] = dtype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.30"
+version = "1.5.31"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make schema in eval preproc explicit and add test for missing schema error.
> 
>   - **Behavior**:
>     - Makes schema in eval preproc explicit by setting `input_schema` to `{}` in `_validate_source_pre_proc()` in `to_proto.py` and `_preproc_df()` in `data_engine.py`.
>     - Adds test `test_invalid_eval_preproc_without_schema` in `test_invalid_connectors.py` to raise error if schema is not provided.
>   - **Versioning**:
>     - Updates version to `1.5.31` in `pyproject.toml` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for a6b86e66d9c5fdb16526657704e2996f7b5e8baf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->