### PR TITLE
[FIX] Fix bug in signature of assign operator.

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.31] - 2024-09-26
+- Fix bug in signature of assign operator.
+
 ## [1.5.30] - 2024-09-24
 - Add hour, minute, second, millisecond, microsecond, day, week accessors as properties instead of methods.
 

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -521,27 +521,21 @@ class Assign(_Node):
         return Assign(self, None, None, None, **kwargs)
 
     def signature(self):
-        if isinstance(self.node, Dataset):
-            return fhash(
-                self.node._name,
-                self.func,
-                self.column,
-                (
-                    self.output_type.__name__
-                    if self.output_type is not None
-                    else None
-                ),
-            )
+        item = (
+            self.node._name
+            if isinstance(self.node, Dataset)
+            else self.node.signature()
+        )
         if self.assign_type == UDFType.python:
             return fhash(
-                self.node.signature(),
+                item,
                 self.func,
                 self.column,
                 self.output_type.__name__,
             )
         else:
             return fhash(
-                self.node.signature(),
+                item,
                 self.output_expressions,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.30"
+version = "1.5.31"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix bug in `Assign` class `signature()` method to handle non-`Dataset` nodes and add test for complex union operations.
> 
>   - **Bug Fix**:
>     - Fix `signature()` method in `Assign` class in `datasets.py` to handle non-`Dataset` nodes using `self.node.signature()`.
>   - **Testing**:
>     - Add `test_complex_union` in `test_dataset.py` to verify complex union operations involving `Assign` operator.
>   - **Version Update**:
>     - Update version to `1.5.31` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 2fb988f59c92e5ebe8d8ede7d4d39b77b939ff7f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->