### PR TITLE
Remove 1us deduction from deletes in latest

### DIFF
--- a/examples/fraud/tests/test_driver_payment_features.py
+++ b/examples/fraud/tests/test_driver_payment_features.py
@@ -153,7 +153,7 @@ def test_min_max_radar_score(client):
     assert log_response.status_code == 200, log_response.json()
 
     df = client.get_dataset_df("TransactionsDS")
-    assert df.shape[0] == 327
+    assert df.shape[0] == 165
 
 
 @mock

--- a/fennel/testing/test_data_engine.py
+++ b/fennel/testing/test_data_engine.py
@@ -60,13 +60,13 @@ def test_add_delete_timestamps(client):
     assert deleted_rows.shape[0] == 3
     assert internal_df.loc[0, FENNEL_DELETE_TIMESTAMP] == pd.Timestamp(
         "2021-01-04 00:00:00+0000", tz="UTC"
-    ) - pd.Timedelta("1us")
+    )
     assert internal_df.loc[1, FENNEL_DELETE_TIMESTAMP] == pd.Timestamp(
         "2021-01-06 00:00:00+0000", tz="UTC"
-    ) - pd.Timedelta("1us")
+    )
     assert internal_df.loc[3, FENNEL_DELETE_TIMESTAMP] == pd.Timestamp(
         "2021-01-05 00:00:00+0000", tz="UTC"
-    ) - pd.Timedelta("1us")
+    )
 
     client.commit(datasets=[UnkeyedTestDataset], message="Add data")
     log(UnkeyedTestDataset, df)

--- a/fennel/testing/test_utils.py
+++ b/fennel/testing/test_utils.py
@@ -376,9 +376,7 @@ def add_deletes(
                 last_index_for_key[key] = i
                 continue
             # Add the timestamp of the current row as the delete timestamp for the last row
-            # Subtract 1 microsecond to ensure that the delete timestamp is strictly less than the
-            # timestamp of the next row
-            del_ts = row[ts_col] - pd.Timedelta("1us")
+            del_ts = row[ts_col]
             delete_timestamps[last_index] = del_ts
             last_index_for_key[key] = i
 


### PR DESCRIPTION
1us deduction has been removed from server code. In this change,
we remove it from client code as well.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 1 microsecond deduction from delete timestamps in client code, updating tests and utility functions accordingly.
> 
>   - **Behavior**:
>     - Remove 1 microsecond deduction from delete timestamps in `test_add_delete_timestamps()` in `test_data_engine.py` and `add_deletes()` in `test_utils.py`.
>     - Update `test_min_max_radar_score()` in `test_driver_payment_features.py` to reflect new dataset size.
>   - **Tests**:
>     - Adjust assertions in `test_add_delete_timestamps()` to match new delete timestamp logic.
>     - Update expected dataset size in `test_min_max_radar_score()` from 327 to 165.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for e08701ef1ad9eb4100b37aa8f0fdbc51d7906611. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->