### PR TITLE
query_offline: Remove format parameter from query_offline

### DIFF
--- a/docs/examples/api-reference/client.py
+++ b/docs/examples/api-reference/client.py
@@ -11,6 +11,7 @@ from fennel.featuresets import feature as F, featureset, extractor
 from fennel.lib import includes, meta, inputs, outputs
 from fennel.testing import mock
 from fennel.expr.expr import col, lit, when
+from fennel.client import Client
 
 webhook = Webhook(name="fennel_webhook")
 
@@ -120,7 +121,6 @@ class TestExtractorDAGResolution(unittest.TestCase):
         response = client.query_offline(
             outputs=[UserFeatures],
             inputs=[UserFeatures.userid],
-            format="pandas",
             input_dataframe=pd.DataFrame(
                 {"UserFeatures.userid": [18232, 18234], "timestamp": [now, now]}
             ),
@@ -136,7 +136,7 @@ class TestExtractorDAGResolution(unittest.TestCase):
         )
         # /docsnip
 
-        with self.assertRaises(NotImplementedError) as e:
+        with self.assertRaises(ValueError) as e:
             # docsnip query_offline_s3
             from fennel.connectors import S3
 
@@ -153,12 +153,12 @@ class TestExtractorDAGResolution(unittest.TestCase):
             response = client.query_offline(
                 outputs=[UserFeatures],
                 inputs=[UserFeatures.userid],
-                format="csv",
                 timestamp_column="timestamp",
                 input_s3=s3_input_connection,
                 output_s3=s3_output_connection,
             )
             # /docsnip
-        assert "Only pandas format is supported in MockClient" in str(
-            e.exception
+        assert (
+            "input must contain a key 'input_dataframe' with the input dataframe"
+            in str(e.exception)
         )

--- a/docs/examples/getting-started/quickstart.py
+++ b/docs/examples/getting-started/quickstart.py
@@ -173,7 +173,6 @@ feature_df = client.query_offline(
         UserSellerFeatures.seller_id,
     ],
     timestamp_column="timestamps",
-    format="pandas",
     input_dataframe=pd.DataFrame(
         [[1, 1, now], [1, 2, now], [1, 1, now - day], [1, 2, now - day]],
         columns=[

--- a/docs/pages/api-reference/client/query-offline.md
+++ b/docs/pages/api-reference/client/query-offline.md
@@ -21,16 +21,12 @@ either as Feature objects, or Featureset objects (in which case all features und
 that featureset are queried) or strings representing fully qualified feature names.
 </Expandable>
 
-<Expandable title="format" type='"pandas" | "csv" | "json" | "parquet"' defaultVal="pandas">
-The format of the input data
-</Expandable>
-
-<Expandable title="input_dataframe" type="pd.Dataframe">
+<Expandable title="input_dataframe" type="Optional[pd.Dataframe]">
 A pandas dataframe object that contains the values of all features in the inputs
 list. Each row of the dataframe can be thought of as one entity for which 
 features need to be queried.
 
-Only relevant when `format` is "pandas".
+This parameter is mutually exclusive with `input_s3`.
 </Expandable>
 
 <Expandable title="input_s3" type="Optional[connectors.S3]">
@@ -38,8 +34,6 @@ Sending large volumes of the input data over the wire is often infeasible.
 In such cases, input data can be written to S3 and the location of the file is
 sent as `input_s3` via `S3.bucket()` function of [S3](/api-reference/connectors/s3) 
 connector. 
-
-This parameter makes sense only when `format` isn't "pandas".
 
 When using this option, please ensure that Fennel's data connector 
 IAM role has the ability to execute read & list operations on this bucket - 
@@ -115,7 +109,7 @@ in order to resolve the path from the input features to the output features.
 
 ===
 <pre name="Request" snippet="api-reference/client/query#extract_historical_api"
-  status="success" message="Example with `format='pandas'` & default s3 output"
+  status="success" message="Example with pandas input & default s3 output"
 ></pre>
 <pre name="Response" snippet="api-reference/client/query#extract_historical_response"
   status="success" message="Response of extract historical"

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [1.5.36] - 2024-10-09
+- Remove format parameter from query_offline.
+
 ## [1.5.35] - 2024-10-08
 - Enable discrete window aggregation.
 

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -457,7 +457,6 @@ class Client:
         inputs: List[Union[Feature, str]],
         outputs: List[Union[Feature, Featureset, str]],
         timestamp_column: str,
-        format: str = "pandas",
         input_dataframe: Optional[pd.DataFrame] = None,
         input_s3: Optional[S3Connector] = None,
         output_s3: Optional[S3Connector] = None,
@@ -481,18 +480,14 @@ class Client:
 
         timestamp_column (str): The name of the column containing timestamps.
 
-        format (str): The format of the input data. Can be either "pandas",
-            "csv", "json" or "parquet". Default is "pandas".
-
         input_dataframe (Optional[pd.DataFrame]): Dataframe containing the input
-            features. Only relevant when format is "pandas".
+            features.
 
         output_s3 (Optional[S3Connector]): Contains the S3 info -- bucket,
             prefix, and optional access key id and secret key -- used for
             storing the output of the extract historical request
 
-        The following parameters are only relevant when format is "csv", "json"
-            or "parquet".
+        The following parameters are only relevant when the input data is provided via S3
 
         input_s3 (Optional[connectors.S3Connector]): The info for the input S3
             data, containing bucket, prefix, and optional access key id and
@@ -509,13 +504,6 @@ class Client:
         indicates that all processing has been completed. A failure rate of 0.0
         indicates that all processing has been completed successfully.
         """
-        if format not in ["pandas", "csv", "json", "parquet"]:
-            raise Exception(
-                "Invalid input format. "
-                "Please provide one of the following formats: "
-                "'pandas', 'csv', 'json' or 'parquet'."
-            )
-
         input_feature_names = []
         for input_feature in inputs:
             if isinstance(input_feature, Feature):
@@ -535,12 +523,7 @@ class Client:
 
         input_info: Dict[str, Any] = {}
         extract_historical_input = {}
-        if format == "pandas":
-            if input_dataframe is None:
-                raise Exception(
-                    "Input dataframe not found in input dictionary. "
-                    "Please provide a dataframe as value for the key 'input_dataframe'."
-                )
+        if input_dataframe is not None:
             if not isinstance(input_dataframe, pd.DataFrame):
                 raise Exception(
                     "Input dataframe is not of type pandas.DataFrame, "

--- a/fennel/testing/mock_client.py
+++ b/fennel/testing/mock_client.py
@@ -293,16 +293,11 @@ class MockClient(Client):
         inputs: List[Union[Feature, str]],
         outputs: List[Union[Feature, Featureset, str]],
         timestamp_column: str,
-        format: str = "pandas",
         input_dataframe: Optional[pd.DataFrame] = None,
         input_s3: Optional[S3Connector] = None,
         output_s3: Optional[S3Connector] = None,
         feature_to_column_map: Optional[Dict[Feature, str]] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
-        if format != "pandas":
-            raise NotImplementedError(
-                "Only pandas format is supported in MockClient"
-            )
         if input_dataframe is None:
             raise ValueError(
                 "input must contain a key 'input_dataframe' with the input dataframe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.35"
+version = "1.5.36"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `format` parameter from `query_offline` in `client.py` and `mock_client.py`, assuming input is always a pandas DataFrame.
> 
>   - **Behavior**:
>     - Remove `format` parameter from `query_offline()` in `client.py` and `mock_client.py`, assuming input is always a pandas DataFrame.
>   - **Documentation**:
>     - Update `query-offline.md` to remove references to `format` parameter.
>   - **Changelog**:
>     - Add entry in `CHANGELOG.md` for version `1.5.36` noting removal of `format` parameter.
>   - **Versioning**:
>     - Update version to `1.5.36` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 8c6068f8cab686d8f929c22f88e9ba1546aa81c2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->