### PR TITLE
Update docs for some operators

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -20,6 +20,7 @@ const
 concat
 CDF
 Changelog
+changelog
 CIDR
 DDL
 DSL

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -19,6 +19,7 @@ Concat
 const
 concat
 CDF
+Changelog
 CIDR
 DDL
 DSL

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -36,6 +36,7 @@ sidebar:
     pages:
       - "api-reference/operators/aggregate"
       - "api-reference/operators/assign"
+      - "api-reference/operators/changelog"
       - "api-reference/operators/dedup"
       - "api-reference/operators/drop"
       - "api-reference/operators/dropnull"

--- a/docs/pages/api-reference/aggregations/firstk.md
+++ b/docs/pages/api-reference/aggregations/firstk.md
@@ -4,7 +4,7 @@ order: 0
 status: published
 ---
 ### FirstK
-Aggregation to computes a rolling list of the earliest values for each group 
+Aggregation to compute a rolling list of the earliest values for each group 
 within a window. 
 
 #### Parameters
@@ -33,6 +33,11 @@ be maintained at any point.
 <Expandable title="dedup" type="bool">
 If set to True, only distinct values are stored else values stored in the first
 can have duplicates too.
+</Expandable>
+
+<Expandable title="dropnull" type="bool">
+If set to True, None values are dropped from the result. It expects `of` field
+to be of type `Optional[T]` and `into_field` gets the type `List[T]`.
 </Expandable>
 
 <pre snippet="api-reference/aggregations/firstk#basic" status="success" 

--- a/docs/pages/api-reference/aggregations/lastk.md
+++ b/docs/pages/api-reference/aggregations/lastk.md
@@ -4,7 +4,7 @@ order: 0
 status: published
 ---
 ### LastK
-Aggregation to computes a rolling list of the latest values for each group 
+Aggregation to compute a rolling list of the latest values for each group 
 within a window. 
 
 #### Parameters

--- a/docs/pages/api-reference/aggregations/max.md
+++ b/docs/pages/api-reference/aggregations/max.md
@@ -9,7 +9,7 @@ Aggregation to computes a rolling max for each group within a window.
 #### Parameters
 <Expandable title="of" type="str">
 Name of the field in the input dataset over which the max should be computed.
-This field must either be of type `int` or `float`.
+This field must either be of type `int`, `float`, `date` or `datetime`.
 </Expandable>
 
 <Expandable title="window" type="Window">
@@ -19,8 +19,9 @@ values are `"forever"` or any [time duration](/api-reference/data-types/duration
 
 <Expandable title="into_field" type="str">
 The name of the field in the output dataset that should store the result of this
-aggregation. This field is expected to be of type `int` or `float` - same as the
-type of the field in the input dataset corresponding to `of`.
+aggregation. This field is expected to be of type `int`, `float`, `date` or
+`datetime` - same as the type of the field in the input dataset corresponding to
+`of`.
 </Expandable>
 
 <Expandable title="default" type="Union[int, float]">
@@ -34,15 +35,16 @@ dataset.
 </pre>
 
 #### Returns
-<Expandable type="Union[int, float]">
+<Expandable type="Union[int, float, date, datetime]">
 Stores the result of the aggregation in the appropriate field of the output 
 dataset. If there are no rows in the aggregation window, `default` is used.
 </Expandable>
 
 
 #### Errors
-<Expandable title="Max on non int/float types">
-The input column denoted by `of` must either be of `int` or `float` types. 
+<Expandable title="Max on other types">
+The input column denoted by `of` must be of `int`, `float`, `date` or `datetime`
+types. 
 
 Note that unlike SQL, even aggregations over `Optional[int]` or `Optional[float]` 
 aren't allowed.
@@ -55,7 +57,7 @@ input dataset.
 </Expandable>
 
 <pre snippet="api-reference/aggregations/max#incorrect_type" status="error" 
-    message="Can not take max over string, only int or float">
+    message="Can not take max over string; only int, float, date or datetime">
 </pre>
 <pre snippet="api-reference/aggregations/max#non_matching_types" status="error" 
     message="amt is float but max_1d is int">

--- a/docs/pages/api-reference/aggregations/min.md
+++ b/docs/pages/api-reference/aggregations/min.md
@@ -9,7 +9,7 @@ Aggregation to computes a rolling min for each group within a window.
 #### Parameters
 <Expandable title="of" type="str">
 Name of the field in the input dataset over which the min should be computed. 
-This field must either be of type `int` or `float`.
+This field must either be of type `int`, `float`, `date` or `datetime`.
 </Expandable>
 
 <Expandable title="window" type="Window">
@@ -19,8 +19,9 @@ values are `"forever"` or any [time duration](/api-reference/data-types/duration
 
 <Expandable title="into_field" type="str">
 The name of the field in the output dataset that should store the result of this
-aggregation. This field is expected to be of type `int` or `float` - same as the
-type of the field in the input dataset corresponding to `of`.
+aggregation. This field is expected to be of type `int`, `float`, `date` or
+`datetime` - same as the type of the field in the input dataset corresponding to
+`of`.
 </Expandable>
 
 <Expandable title="default" type="Union[int, float]">
@@ -34,15 +35,16 @@ dataset.
 </pre>
 
 #### Returns
-<Expandable type="Union[int, float]">
+<Expandable type="Union[int, float, date, datetime]">
 Stores the result of the aggregation in the appropriate field of the output 
 dataset. If there are no rows in the aggregation window, `default` is used.
 </Expandable>
 
 
 #### Errors
-<Expandable title="Min on non int/float types">
-The input column denoted by `of` must either be of `int` or `float` types. 
+<Expandable title="Min on other types">
+The input column denoted by `of` must be of `int`, `float`, `date` or `datetime`
+types. 
 
 Note that unlike SQL, even aggregations over `Optional[int]` or `Optional[float]` 
 aren't allowed.
@@ -55,7 +57,7 @@ input dataset.
 </Expandable>
 
 <pre snippet="api-reference/aggregations/min#incorrect_type" status="error" 
-    message="Can not take min over string, only int or float">
+    message="Can not take min over string; only int, float, date or datetime">
 </pre>
 <pre snippet="api-reference/aggregations/min#non_matching_types" status="error" 
     message="amt is float but min_1d is int">

--- a/docs/pages/api-reference/operators/changelog.md
+++ b/docs/pages/api-reference/operators/changelog.md
@@ -1,0 +1,41 @@
+---
+title: Changelog
+order: 0
+status: published
+---
+### Changelog
+Operator to convert a keyed dataset into a keyless one, where the underlying delta
+frame of the dataset is presented as a changelog. All key fields are converted into
+normal fields, and an additional column is added which contains the kind (insert
+or delete) of the delta.
+
+#### Parameters
+
+<Expandable title="delete" type="str">
+Kwarg that specifies the name of a boolean column which stores whether a delta was
+a delete kind in the original dataset. Exactly one of this or `insert` kwarg
+should be set.
+</Expandable>
+
+<Expandable title="insert" type="str">
+Kwarg that specifies the name of a boolean column which stores whether a delta was
+an insert kind in the original dataset. Exactly one of this or `delete` kwarg
+should be set.
+</Expandable>
+
+#### Returns
+
+<Expandable type="Dataset">
+Returns a dataset with underlying delta frame of the input dataset is presented as
+a insert only changelog. All key fields converted into normal fields and an additional
+column is added which contains the kind (insert or delete) of the delta.
+</Expandable>
+
+#### Errors
+<Expandable title="Neither insert nor delete kwarg is set">
+Error if neither of `insert` or `delete` kwarg is set.
+</Expandable>
+
+<Expandable title="Both insert and delete kwargs are set">
+Error if both `insert` and `delete` kwargs are set.
+</Expandable>

--- a/docs/pages/api-reference/operators/changelog.md
+++ b/docs/pages/api-reference/operators/changelog.md
@@ -4,10 +4,9 @@ order: 0
 status: published
 ---
 ### Changelog
-Operator to convert a keyed dataset into a keyless one, where the underlying delta
-frame of the dataset is presented as a changelog. All key fields are converted into
-normal fields, and an additional column is added which contains the kind (insert
-or delete) of the delta.
+Operator to convert a keyed dataset into a CDC changelog stream. All key fields
+are converted into normal fields, and an additional column is added, indicating the
+type of change (insert or delete) for the delta.
 
 #### Parameters
 
@@ -26,9 +25,10 @@ should be set.
 #### Returns
 
 <Expandable type="Dataset">
-Returns a dataset with underlying delta frame of the input dataset is presented as
-a insert only changelog. All key fields converted into normal fields and an additional
-column is added which contains the kind (insert or delete) of the delta.
+Returns a dataset with input keyed dataset into an append only CDC changelog
+stream. All key fields converted into normal fields, and an additional
+column is addedm which contains the type of change (insert or delete) for the
+delta.
 </Expandable>
 
 #### Errors

--- a/docs/pages/api-reference/operators/changelog.md
+++ b/docs/pages/api-reference/operators/changelog.md
@@ -27,7 +27,7 @@ should be set.
 <Expandable type="Dataset">
 Returns a dataset with input keyed dataset into an append only CDC changelog
 stream. All key fields converted into normal fields, and an additional
-column is addedm which contains the type of change (insert or delete) for the
+column is added, which contains the type of change (insert or delete) for the
 delta.
 </Expandable>
 

--- a/docs/pages/api-reference/operators/join.md
+++ b/docs/pages/api-reference/operators/join.md
@@ -60,6 +60,15 @@ where (d1, d2) = within.
    should be available for the event time of the LHS data.
 </Expandable>
 
+<Expandable title="fields" type="Optional[List[str]]" defaultVal="None">
+Optional kwarg that specifies the list of (non-key) fields of the right
+dataset that should be included in the output dataset. If this kwarg is
+not set, all such fields are included in the output dataset. If right dataset's
+timestamp field is included in `fields`, then it is included as a normal field
+in the output dataset, with left dataset's timestamp field as the output
+dataset's timestamp field.
+</Expandable>
+
 <pre snippet="api-reference/operators/join#basic" status="success"
    message="Inner join on 'merchant'">
 </pre>


### PR DESCRIPTION
In this change, we update or add documentation for operator
changes done in #553, #556, #535, #560 and #578.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update documentation for `firstk`, `max`, `min`, `changelog`, and `join` operators with new parameters and type clarifications.
> 
>   - **Aggregations**:
>     - `firstk.md`: Add `dropnull` parameter to drop `None` values.
>     - `max.md` and `min.md`: Update `of` and `into_field` types to include `date` and `datetime`.
>   - **Operators**:
>     - `changelog.md`: New file added for `Changelog` operator documentation.
>     - `join.md`: Add `fields` parameter to specify right dataset fields in output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for b601ac180d60e67de26a612e4330c065c810158b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->