### PR TITLE
Client Join Improvement

### DIFF
--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -2938,21 +2938,7 @@ class SchemaValidator(Visitor):
         def is_subset(subset: List[str], superset: List[str]) -> bool:
             return set(subset).issubset(set(superset))
 
-        def validate_right_index(right_dataset: Dataset):
-            right_index = get_index(right_dataset)
-            if right_index is None:
-                raise ValueError(
-                    f"Index needs to be set on the right dataset `{right_dataset._name}` for `{output_schema_name}`."
-                )
-
-            if right_index.offline == IndexDuration.none:
-                raise ValueError(
-                    f"`offline` needs to be set on index of the right dataset `{right_dataset._name}` "
-                    f"for `{output_schema_name}`."
-                )
-
         validate_join_bounds(obj.within)
-        validate_right_index(obj.dataset)
 
         if obj.on is not None and len(obj.on) > 0:
             # obj.on should be the key of the right dataset

--- a/fennel/datasets/test_schema_validator.py
+++ b/fennel/datasets/test_schema_validator.py
@@ -1510,42 +1510,6 @@ def test_window_invalid_gap():
     )
 
 
-def test_join_with_wrong_right_index():
-    with pytest.raises(ValueError) as e:
-
-        @meta(owner="nitin@fennel.ai")
-        @dataset(online=True)
-        class Users:
-            user_id: str = field(key=True)
-            age: int
-            t: datetime
-
-        @meta(owner="nitin@fennel.ai")
-        @dataset
-        class Login:
-            user_id: str
-            cookie: str
-            t: datetime
-
-        @meta(owner="nitin@fennel.ai")
-        @dataset
-        class LoginEvent:
-            user_id: str
-            cookie: str
-            age: int
-            t: datetime
-
-            @pipeline
-            @inputs(Login, Users)
-            def pipeline(cls, login: Dataset, users: Dataset):
-                return login.join(users, on=["user_id"], how="inner")
-
-    assert (
-        str(e.value)
-        == """`offline` needs to be set on index of the right dataset `Users` for `'[Pipeline:pipeline]->join node'`."""
-    )
-
-
 def test_conflicting_key_field_error():
     with pytest.raises(ValueError) as e:
 

--- a/fennel/datasets/test_schema_validator.py
+++ b/fennel/datasets/test_schema_validator.py
@@ -1510,6 +1510,35 @@ def test_window_invalid_gap():
     )
 
 
+def test_join_work_without_offline_index():
+    @meta(owner="nitin@fennel.ai")
+    @dataset()
+    class Users:
+        user_id: str = field(key=True)
+        age: int
+        t: datetime
+
+    @meta(owner="nitin@fennel.ai")
+    @dataset
+    class Login:
+        user_id: str
+        cookie: str
+        t: datetime
+
+    @meta(owner="nitin@fennel.ai")
+    @dataset
+    class LoginEvent:
+        user_id: str
+        cookie: str
+        age: int
+        t: datetime
+
+        @pipeline
+        @inputs(Login, Users)
+        def pipeline(cls, login: Dataset, users: Dataset):
+            return login.join(users, on=["user_id"], how="inner")
+
+
 def test_conflicting_key_field_error():
     with pytest.raises(ValueError) as e:
 

--- a/fennel/testing/executor.py
+++ b/fennel/testing/executor.py
@@ -694,10 +694,7 @@ class Executor(Visitor):
         # specified and join occurred with an entry with larger value than the query ts.
 
         def emited_ts(row):
-            if pd.isnull(row[tmp_right_ts]):
-                return row[tmp_left_ts]
-            else:
-                return max(row[tmp_right_ts], row[tmp_left_ts])
+            return row[tmp_left_ts]
 
         # Handling with empty dataframe case because pandas automatically defines dtype of float64 to null columns
         # and then conversion of flot64 dtype to pd.ArrowDtype(pa.timestamp("us", "UTC")) fails


### PR DESCRIPTION
Two improvements was made here:

+ Join time is now from LHS to match server logic. Table join we might need to do differently but @bothra90 is working on that
+ Join now doesn't require index anymore. This is still blocked by server but will be addressed soon
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Align join time with server logic and remove right index requirement in join functionality.
> 
>   - **Behavior**:
>     - Align join time logic with server by using LHS timestamp in `executor.py`.
>     - Remove right index requirement in `datasets.py`.
>   - **Testing**:
>     - Remove `test_join_with_wrong_right_index()` from `test_schema_validator.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 7c8ec095f6ec51c9f184650903f9c3edc99e9833. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->