### PR TITLE
Add support for Keyless S3 and Snowflake Sinks

### DIFF
--- a/docs/pages/api-reference/sink_connectors/s3.md
+++ b/docs/pages/api-reference/sink_connectors/s3.md
@@ -82,6 +82,9 @@ parameter inside connector params and make sure `FennelDataAccessRole-` can assu
 - Fennel appends a generated suffix to the above provided prefix to avoid ambiguities when the 
 sink dataset version is updated or when multiple branches have the same sink defined. This suffix
 can be found in the 'Sink' tab of the console after initiating a data sink.
+- A keyless dataset sink ensures at least once delivery, while a keyed dataset sink guarantees 
+exactly once delivery. For keyless datasets, use the `__fennel_hash__` column to identify and 
+filter out duplicate deliveries.
 - Fennel supports S3 sink with only delta format and access to S3 through `FennelDataAccessRole-`.
 In case you require support for other formats or access mechanisms, please reach out to Fennel support
 :::

--- a/docs/pages/api-reference/sink_connectors/s3.md
+++ b/docs/pages/api-reference/sink_connectors/s3.md
@@ -84,6 +84,5 @@ sink dataset version is updated or when multiple branches have the same sink def
 can be found in the 'Sink' tab of the console after initiating a data sink.
 - Fennel supports S3 sink with only delta format and access to S3 through `FennelDataAccessRole-`.
 In case you require support for other formats or access mechanisms, please reach out to Fennel support
-- Currently, Fennel only supports keyed dataset sinks to S3. Support for keyless datasets will be added soon.
 :::
 

--- a/docs/pages/api-reference/sink_connectors/snowflake.md
+++ b/docs/pages/api-reference/sink_connectors/snowflake.md
@@ -71,6 +71,9 @@ do this validation at commit time.
 when the sink dataset version is updated or when multiple branches have the same 
 sink defined. This suffix can be viewed in the 'Sink' tab of the console after 
 initiating a data sink.
+- A keyless dataset sink ensures at least once delivery, while a keyed dataset sink guarantees 
+exactly once delivery. For keyless datasets, use the `__fennel_hash__` column to identify and 
+filter out duplicate deliveries.
 :::
 
 

--- a/docs/pages/api-reference/sink_connectors/snowflake.md
+++ b/docs/pages/api-reference/sink_connectors/snowflake.md
@@ -71,8 +71,6 @@ do this validation at commit time.
 when the sink dataset version is updated or when multiple branches have the same 
 sink defined. This suffix can be viewed in the 'Sink' tab of the console after 
 initiating a data sink.
-- Currently, Fennel only supports keyed dataset sinks to Snowflake. Support 
-for keyless datasets will be added soon.
 :::
 
 

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.43] - 2024-10-23
+- Add support for keyless S3 and Snowflake sinks
+
 ## [1.5.42] - 2024-10-23
 - Increase client timeouts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.42"
+version = "1.5.43"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
Updated below documentation for both S3 and Snowflake Sinks 

<img width="368" alt="Screenshot 2024-10-20 at 2 13 36 PM" src="https://github.com/user-attachments/assets/9f806b61-6f26-4eb7-9d95-1741a3757809">

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for keyless dataset sinks in S3 and Snowflake, updating documentation and versioning.
> 
>   - **Documentation**:
>     - Updated `s3.md` and `snowflake.md` to include support for keyless dataset sinks.
>     - Keyless sinks ensure at least once delivery; use `__fennel_hash__` to filter duplicates.
>   - **Changelog**:
>     - Updated `CHANGELOG.md` to version 1.5.43 with keyless sink support.
>   - **Versioning**:
>     - Updated version in `pyproject.toml` to 1.5.43.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for ce909a9a887744cf03fe1688ba46f282a496ebc0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->