### PR TITLE
query_offline: Use thunder by default

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.48] - 2024-11-06
+- Use v2 by default in query_offline
+
 ## [1.5.47] - 2024-10-31
 - Add support for certificate based authentication for HTTP sink
 

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -461,7 +461,7 @@ class Client:
         input_s3: Optional[S3Connector] = None,
         output_s3: Optional[S3Connector] = None,
         feature_to_column_map: Optional[Dict[Feature, str]] = None,
-        use_v2: bool = False,
+        use_v2: bool = True,
     ) -> Dict[str, Any]:
         """Extract point in time correct values of output features.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.47"
+version = "1.5.48"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default `use_v2` to `True` in `query_offline()` in `client.py` and update version to `1.5.48`.
> 
>   - **Behavior**:
>     - Change default `use_v2` to `True` in `query_offline()` in `client.py`.
>   - **Changelog**:
>     - Update `CHANGELOG.md` to reflect the change in `query_offline` default behavior.
>   - **Versioning**:
>     - Bump version to `1.5.48` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for a246f07bda3b02ced3abaf7bb5c7e1ddba7f1382. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->