### PR TITLE
expr: add print visitor to few more expressions

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.55] - 2024-11-14
+- Add print visitor for couple missing string operations
+
 ## [1.5.54] - 2024-11-12
 - Add backfill parameter to commit operation
 

--- a/fennel/expr/visitor.py
+++ b/fennel/expr/visitor.py
@@ -39,11 +39,15 @@ from fennel.expr.expr import (
     Floor,
     StringNoop,
     StringParse,
+    StringJsonExtract,
     StrLen,
     Lower,
     Upper,
     StringStrpTime,
     StrContains,
+    StrStartsWith,
+    StrEndsWith,
+    StringSplit,
     DictContains,
     Concat,
     DictGet,
@@ -301,6 +305,14 @@ class ExprPrinter(Visitor):
             return f"STRPTIME({self.visit(obj.operand)}, {obj.op.format})"
         elif isinstance(obj.op, StringParse):
             return f"PARSE({self.visit(obj.operand)}, {obj.op.dtype})"
+        elif isinstance(obj.op, StrStartsWith):
+            return f"STARTSWITH({self.visit(obj.operand)}, {self.visit(obj.op.item)})"
+        elif isinstance(obj.op, StrEndsWith):
+            return f"ENDSWITH({self.visit(obj.operand)}, {self.visit(obj.op.item)})"
+        elif isinstance(obj.op, StringJsonExtract):
+            return f"JSON_EXTRACT({self.visit(obj.operand)}, {obj.op.path})"
+        elif isinstance(obj.op, StringSplit):
+            return f"SPLIT({self.visit(obj.operand)}, {obj.op.sep})"
         else:
             raise InvalidExprException("invalid string operation: %s" % obj.op)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.54"
+version = "1.5.55"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add print visitor support for `StrStartsWith`, `StrEndsWith`, `StringJsonExtract`, and `StringSplit` in `ExprPrinter` and update version to 1.5.55.
> 
>   - **Behavior**:
>     - Add print visitor support for `StrStartsWith`, `StrEndsWith`, `StringJsonExtract`, and `StringSplit` in `visitString()` in `ExprPrinter`.
>   - **Changelog**:
>     - Update `CHANGELOG.md` to version 1.5.55 with details of added print visitor support for string operations.
>   - **Versioning**:
>     - Update version in `pyproject.toml` to 1.5.55.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for bec5a0f345ccc87c17d81ba2fd6149581d1679a7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->