### PR TITLE
change inner join null behaviour

### DIFF
--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -1062,9 +1062,6 @@ class Join(_Node):
 
         rhs_keys = set(self.dataset.dsschema().keys)
         join_keys = set(self.on) if self.on is not None else set(self.right_on)
-        final_join_cols = (
-            set(self.on) if self.on is not None else set(self.left_on)
-        )
         # Ensure on or right_on are the keys of the right dataset
         if join_keys != rhs_keys:
             raise ValueError(
@@ -1132,11 +1129,6 @@ class Join(_Node):
                 )
             else:
                 joined_dsschema.append_value_column(right_ts, datetime.datetime)
-
-        # Drop null on join keys if how is inner
-        if self.how == "inner":
-            for key in final_join_cols:
-                joined_dsschema.drop_null_column(key)
 
         return joined_dsschema
 

--- a/fennel/datasets/test_schema_validator.py
+++ b/fennel/datasets/test_schema_validator.py
@@ -2001,7 +2001,7 @@ def test_keyed_input_aggregate():
 def test_optional_join():
 
     # Test that optional can join
-    # inner join drop null on join keys
+    # inner join should notdrop null on join keys
     if True:
 
         @dataset
@@ -2020,7 +2020,7 @@ def test_optional_join():
 
         @dataset
         class XYZJoinedABC:  # noqa: F811
-            user_id: int
+            user_id: Optional[int]
             agent_id: int
             name: str
             age: int
@@ -2063,76 +2063,6 @@ def test_optional_join():
             def create_pipeline(cls, a: Dataset, b: Dataset):
                 c = a.join(b, how="left", left_on=["user_id", "agent_id"], right_on=["user_id_2", "agent_id_2"])  # type: ignore
                 return c
-
-    # Test wrong optional
-    with pytest.raises(TypeError) as e:
-
-        @dataset
-        class XYZ:
-            user_id: Optional[str]
-            agent_id: int
-            name: str
-            timestamp: datetime
-
-        @dataset(index=True)
-        class ABC:
-            user_id: int = field(key=True)
-            agent_id: int = field(key=True)
-            age: int
-            timestamp: datetime
-
-        @dataset
-        class XYZJoinedABC:  # noqa: F811
-            user_id: Optional[int]
-            agent_id: int
-            name: str
-            age: int
-            timestamp: datetime
-
-            @pipeline
-            @inputs(XYZ, ABC)
-            def create_pipeline(cls, a: Dataset, b: Dataset):
-                c = a.join(b, how="inner", on=["user_id", "agent_id"])  # type: ignore
-                return c
-
-    assert str(e.value) == (
-        "Key field `user_id` has type `Optional[str]` in left schema but type `int` in right schema for `'[Pipeline:create_pipeline]->join node'`"
-    )
-
-    # After inner join, optional type should be removed
-    with pytest.raises(TypeError) as e:
-
-        @dataset
-        class XYZ:
-            user_id: Optional[int]
-            agent_id: int
-            name: str
-            timestamp: datetime
-
-        @dataset(index=True)
-        class ABC:
-            user_id: int = field(key=True)
-            agent_id: int = field(key=True)
-            age: int
-            timestamp: datetime
-
-        @dataset
-        class XYZJoinedABC:  # noqa: F811
-            user_id: Optional[int]
-            agent_id: int
-            name: str
-            age: int
-            timestamp: datetime
-
-            @pipeline
-            @inputs(XYZ, ABC)
-            def create_pipeline(cls, a: Dataset, b: Dataset):
-                c = a.join(b, how="inner", on=["user_id", "agent_id"])  # type: ignore
-                return c
-
-    assert str(e.value) == (
-        "[TypeError('Field `user_id` has type `int` in `pipeline create_pipeline output value` schema but type `Optional[int]` in `XYZJoinedABC value` schema.')]"
-    )
 
     # If left join, optional type should not be dropped
     with pytest.raises(TypeError) as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.56"
+version = "1.5.57"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
Inner join on null value shouldn't drop the null value on the output schema.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Inner joins now retain null values in the output schema, with tests updated to verify this behavior, and version bumped to 1.5.57.
> 
>   - **Behavior**:
>     - Inner joins now retain null values in the output schema in `datasets.py`.
>   - **Tests**:
>     - Updated `test_optional_join` in `test_schema_validator.py` to verify that inner joins do not drop null values.
>   - **Misc**:
>     - Bump version to 1.5.57 in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 370fd0d95289571a03c24fd1b87e3431f10b0381. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->