### PR TITLE
aggregation: add warnings for aggregations on top of keyed datasets

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.61] - 2024-12-12
+- Add appropriate warnings for aggregations on top of keyed datasets.
+
 ## [1.5.60] - 2024-12-10
 - Add support for indirections in preproc ref type for Avro format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.60"
+version = "1.5.61"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add warnings for aggregations on keyed datasets in `visitAggregate` and update version to `1.5.61`.
> 
>   - **Behavior**:
>     - Add warning in `visitAggregate` in `datasets.py` for aggregations on keyed datasets unless all windows are discrete forever or `along` is set.
>     - Update logic to determine `all_discrete`, `all_continuous`, and `all_discrete_forever` in `visitAggregate`.
>     - Modify `is_terminal` condition to use `all_continuous` in `visitAggregate`.
>   - **Versioning**:
>     - Update version to `1.5.61` in `pyproject.toml` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 16e8cb68a7ea8851067361d267b0be6cf2187bf3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->