### PR TITLE
fix casting with empty dataframe

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.62] - 2024-12-16
+- Fix casting for empty dataframes.
+
 ## [1.5.61] - 2024-12-12
 - Add appropriate warnings for aggregations on top of keyed datasets.
 

--- a/fennel/testing/executor.py
+++ b/fennel/testing/executor.py
@@ -334,7 +334,7 @@ class Executor(Visitor):
 
             for col in key_dfs.columns:
                 # If any of the columns is a dictionary, convert it to a frozen dict
-                if key_dfs[col].apply(lambda x: isinstance(x, dict)).any():
+                if any([isinstance(x, dict) for x in key_dfs[col].tolist()]):
                     key_dfs[col] = key_dfs[col].apply(lambda x: frozendict(x))
 
             # Find the values for all columns as of the timestamp in key_dfs

--- a/fennel/testing/test_utils.py
+++ b/fennel/testing/test_utils.py
@@ -381,7 +381,9 @@ def add_deletes(
             last_index_for_key[key] = i
 
     # Add the delete timestamp as a hidden column to the dataframe
-    sorted_df[FENNEL_DELETE_TIMESTAMP] = delete_timestamps
+    sorted_df[FENNEL_DELETE_TIMESTAMP] = pd.Series(
+        delete_timestamps, dtype=pd.ArrowDtype(pa.timestamp("ns", "UTC"))
+    )
 
     if len(rows_to_delete) > 0:
         # Drop the rows that are marked for deletion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.61"
+version = "1.5.62"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix casting issues for empty dataframes in `executor.py` and `test_utils.py`, updating version to 1.5.62.
> 
>   - **Behavior**:
>     - Fix casting for empty dataframes in `join_aggregated_dataset` in `executor.py` by changing dictionary check in columns.
>     - Ensure `FENNEL_DELETE_TIMESTAMP` is cast to Arrow dtype in `add_deletes` in `test_utils.py`.
>   - **Versioning**:
>     - Update version to `1.5.62` in `pyproject.toml` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for e26d175394ba71050eb65734fe189d0539e336d6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->