### PR TITLE
mockclient: Add support for deleted datasets in mock client

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## [1.5.66] - 2025-01-01
+- Add support for deleted datasets in mock client.
+
 ## [1.5.65] - 2024-12-27
 - Support default in alias extractors.
 

--- a/fennel/client_tests/test_featureset.py
+++ b/fennel/client_tests/test_featureset.py
@@ -1419,6 +1419,7 @@ def test_chainedlist_lookup_with_default(client):
         message="Initial commit",
     )
 
+    client.sleep()
     now = datetime.now(timezone.utc)
     data = [
         [18232, "John", 32, "USA", now, ["Reading", "Writing"]],

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -58,6 +58,7 @@ from fennel.dtypes.dtypes import (
 )
 from fennel.expr import Expr
 from fennel.gen import schema_pb2 as schema_proto
+from fennel.internal_lib import META_FIELD
 from fennel.internal_lib.duration import (
     Duration,
     duration_to_timedelta,
@@ -2048,6 +2049,12 @@ class Dataset(_Node[T]):
         if hasattr(expectation.func, "__fennel_metadata__"):
             raise ValueError("Expectations cannot have metadata.")
         return expectation
+
+    def is_deleted(self):
+        if hasattr(self, META_FIELD):
+            metadata = getattr(self, META_FIELD)
+            return metadata.deleted
+        return False
 
     def num_pipelines(self):
         return len(self._pipelines)

--- a/fennel/testing/mock_client.py
+++ b/fennel/testing/mock_client.py
@@ -174,6 +174,10 @@ class MockClient(Client):
             else:
                 return dataset_old.signature() == dataset_new.signature()
 
+        if datasets is not None:
+            datasets = [
+                dataset for dataset in datasets if not dataset.is_deleted()
+            ]
         if incremental:
             cur_datasets = self.get_datasets()
             cur_featuresets = self.get_featuresets()

--- a/poetry.lock
+++ b/poetry.lock
@@ -3601,18 +3601,19 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "twine"
-version = "4.0.2"
+version = "6.0.1"
 description = "Collection of utilities for publishing packages on PyPI"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "twine-4.0.2-py3-none-any.whl", hash = "sha256:929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8"},
-    {file = "twine-4.0.2.tar.gz", hash = "sha256:9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8"},
+    {file = "twine-6.0.1-py3-none-any.whl", hash = "sha256:9c6025b203b51521d53e200f4a08b116dee7500a38591668c6a6033117bdc218"},
+    {file = "twine-6.0.1.tar.gz", hash = "sha256:36158b09df5406e1c9c1fb8edb24fc2be387709443e7376689b938531582ee27"},
 ]
 
 [package.dependencies]
-importlib-metadata = ">=3.6"
-keyring = ">=15.1"
+importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
+keyring = {version = ">=15.1", markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\""}
+packaging = "*"
 pkginfo = ">=1.8.1"
 readme-renderer = ">=35.0"
 requests = ">=2.20"
@@ -3620,6 +3621,9 @@ requests-toolbelt = ">=0.8.0,<0.9.0 || >0.9.0"
 rfc3986 = ">=1.4.0"
 rich = ">=12.0.0"
 urllib3 = ">=1.26.0"
+
+[package.extras]
+keyring = ["keyring (>=15.1)"]
 
 [[package]]
 name = "types-protobuf"
@@ -3804,4 +3808,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "1822fa046fbeb93232773ae348e6dfd41fd5e4611cb1a1b5cd3a2f85e25ba79e"
+content-hash = "2bf388c7c2d67ad3efb1e55d57089d519167867e1dc2c279e97cef638b851669"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.65"
+version = "1.5.66"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]
@@ -23,6 +23,7 @@ typing-extensions = "^4.12.0"
 fennel-data-lib = "0.1.25"
 pyarrow = "^14.0.2"
 attrs = "^24.3.0"
+twine = "^6.0.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"
@@ -37,7 +38,6 @@ geopy = "^2.3.0"
 jupyterlab = "^4.0.10"
 pytest-mock = "^3.9.0"
 pytest = "^7.1.3"
-twine = "^4.0.0"
 pyspelling = "^2.8.2"
 # A pyyaml bug when using cython, https://github.com/yaml/pyyaml/issues/601
 pyyaml = "^6.0.1"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for handling deleted datasets in `MockClient` and update tests and version.
> 
>   - **Behavior**:
>     - `commit()` in `mock_client.py` filters out deleted datasets using `is_deleted()`.
>   - **Tests**:
>     - Added `test_deleted_dataset` in `test_invalid_dataset.py` to verify behavior with deleted datasets.
>   - **Misc**:
>     - Version bump to `1.5.66` in `pyproject.toml`.
>     - Added `twine` to dependencies in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 4de7c8ec4897dc0fbc50001b416ad570f31fb06d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->