### PR TITLE
Fix backward compatibility for alias extractor type

### DIFF
--- a/docs/examples/api-reference/expressions/basic.py
+++ b/docs/examples/api-reference/expressions/basic.py
@@ -177,7 +177,7 @@ def test_now():
     )
     assert expr.eval(df, schema={"birthdate": Optional[datetime]}).tolist() == [
         27,
-        23,
+        24,
         pd.NA,
     ]
     # /docsnip

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.69] - 2025-01-15
+- Fix backward compatibility for alias extractor type
+
 ## [1.5.68] - 2025-01-14
 - Use pycurl instead of requests for client.
 

--- a/fennel/client_tests/test_expr.py
+++ b/fennel/client_tests/test_expr.py
@@ -89,7 +89,7 @@ def test_now(client):
         "Rachel",
         pd.NA,
     ]
-    assert df["UserInfoFeatures.age"].tolist() == [55, 44, 34, 27, 23, pd.NA]
+    assert df["UserInfoFeatures.age"].tolist() == [55, 44, 34, 27, 24, pd.NA]
     assert df["UserInfoFeatures.country"].tolist() == [
         "India",
         "USA",
@@ -136,7 +136,7 @@ def test_now(client):
             43,
             33,
             26,
-            22,
+            23,
             pd.NA,
         ]
         assert df["UserInfoFeatures.country"].tolist() == [

--- a/fennel/featuresets/test_derived_extractors.py
+++ b/fennel/featuresets/test_derived_extractors.py
@@ -240,10 +240,7 @@ def test_valid_derived_extractors():
             "feature_set_name": "UserInfo",
             "extractor_type": fs_proto.ALIAS,
             "field_info": None,
-            "alias_info": {
-                "defaultValue": "null",
-                "dtype": {"int_type": {}},
-            },
+            "alias_info": None,
         },
         {
             "name": "_fennel_lookup_UserInfoDataset.gender",
@@ -384,10 +381,7 @@ def test_valid_derived_extractors():
             "feature_set_name": "AgeInfo",
             "extractor_type": fs_proto.ALIAS,
             "field_info": None,
-            "alias_info": {
-                "defaultValue": "null",
-                "dtype": {"struct_type": age_group_struct_type},
-            },
+            "alias_info": None,
         },
         {
             "name": "_fennel_alias_UserInfo.age_years",
@@ -410,10 +404,7 @@ def test_valid_derived_extractors():
             "feature_set_name": "AgeInfo",
             "extractor_type": fs_proto.ALIAS,
             "field_info": None,
-            "alias_info": {
-                "defaultValue": "null",
-                "dtype": {"int_type": {}},
-            },
+            "alias_info": None,
         },
     ]
     for i, e in enumerate(sync_request.extractors):

--- a/fennel/internal_lib/to_proto/to_proto.py
+++ b/fennel/internal_lib/to_proto/to_proto.py
@@ -808,11 +808,10 @@ def _to_field_lookup_proto(
 
 def _to_alias_info_proto(
     info: Extractor.AliasInfo,
-) -> fs_proto.AliasInfo:
+) -> Optional[fs_proto.AliasInfo]:
+    # Backward compatibility cases
     if info.default is None:
-        return fs_proto.AliasInfo(
-            dtype=get_datatype(info.dtype), default_value=json.dumps(None)
-        )
+        return None
     default_val = val_as_json(info.default)
     return fs_proto.AliasInfo(
         dtype=get_datatype(info.dtype),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.68"
+version = "1.5.69"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix backward compatibility for alias extractor type by setting `alias_info` to `None` when default is `None`, updating tests and documentation, and incrementing version to 1.5.69.
> 
>   - **Behavior**:
>     - Fix backward compatibility for alias extractor type by setting `alias_info` to `None` when default is `None` in `_to_alias_info_proto()` in `to_proto.py`.
>     - Update test cases in `test_derived_extractors.py` and `test_expr.py` to reflect changes in `alias_info` handling.
>   - **Documentation**:
>     - Update `basic.py` example to reflect changes in expression evaluation results.
>   - **Versioning**:
>     - Update version to 1.5.69 in `pyproject.toml` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for d99c07ab90b98c053443464962f463a8e397e9fb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->