### PR TITLE
assign: Make output type name optional

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [1.5.73] - 2025-02-04
+- Fix issue in type name in assigns
+
 ## [1.5.72] - 2025-01-21
 - Fix deleted entities during commit in mock client
 

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -534,12 +534,19 @@ class Assign(_Node):
             else self.node.signature()
         )
         if self.assign_type == UDFType.python:
-            return fhash(
-                item,
-                self.func,
-                self.column,
-                self.output_type.__name__,
-            )
+            try:
+                return fhash(
+                    item,
+                    self.func,
+                    self.column,
+                    self.output_type.__name__,
+                )
+            except Exception:
+                return fhash(
+                    item,
+                    self.func,
+                    self.column,
+                )
         else:
             return fhash(
                 item,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.72"
+version = "1.5.73"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `output_type.__name__` optional in `Assign.signature()` by handling exceptions, update version to `1.5.73`.
> 
>   - **Behavior**:
>     - In `Assign.signature()` in `datasets.py`, make `output_type.__name__` optional by catching exceptions and returning a hash without it if an exception occurs.
>   - **Versioning**:
>     - Update version to `1.5.73` in `pyproject.toml`.
>     - Update `CHANGELOG.md` to reflect the change in `assign` output type name handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for efa40df8004ee4decec22081d9588cb54a611829. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->