### PR TITLE
rename `is_deleted` to prevent collisions with user fields

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.5.76] - 2025-02-13
+- Bug fix: rename `is_deleted` to `__fennel_is_deleted__` in datasets, 
+  featuresets and features to prevent collision with user defined fields
+
 ## [1.5.75] - 2025-02-06
 - Stop sending deleted features in query_offline request
 

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -588,7 +588,7 @@ class Client:
         output_feature_names = []
         for output_feature in outputs:
             if isinstance(output_feature, Feature):
-                if output_feature.is_deleted():
+                if output_feature.__fennel_is_deleted__():
                     raise Exception(
                         f"Feature {output_feature.fqn()} is deleted. Please provide a valid feature for output_feature."
                     )
@@ -603,7 +603,7 @@ class Client:
                         f"Please provide a valid string for output_feature, got : `{output_feature}`."
                     )
             elif isinstance(output_feature, Featureset):
-                if output_feature.is_deleted():
+                if output_feature.__fennel_is_deleted__():
                     raise Exception(
                         f"Featureset {output_feature} is deleted. Please provide a valid featureset for output_feature."
                     )
@@ -611,7 +611,7 @@ class Client:
                     [
                         f.fqn()
                         for f in output_feature.features
-                        if not f.is_deleted()
+                        if not f.__fennel_is_deleted__()
                     ]
                 )
 

--- a/fennel/datasets/datasets.py
+++ b/fennel/datasets/datasets.py
@@ -1803,6 +1803,12 @@ class Dataset(_Node[T]):
     def __class_getitem__(cls, item):
         return item
 
+    def __fennel_is_deleted__(self):
+        if hasattr(self, META_FIELD):
+            metadata = getattr(self, META_FIELD)
+            return metadata.deleted
+        return False
+
     # ------------------- Public Methods --------------------------
 
     def signature(self):
@@ -2056,12 +2062,6 @@ class Dataset(_Node[T]):
         if hasattr(expectation.func, "__fennel_metadata__"):
             raise ValueError("Expectations cannot have metadata.")
         return expectation
-
-    def is_deleted(self):
-        if hasattr(self, META_FIELD):
-            metadata = getattr(self, META_FIELD)
-            return metadata.deleted
-        return False
 
     def num_pipelines(self):
         return len(self._pipelines)

--- a/fennel/featuresets/featureset.py
+++ b/fennel/featuresets/featureset.py
@@ -366,7 +366,7 @@ class Feature:
     dtype: Optional[Type] = None
     deprecated: bool = False
 
-    def is_deleted(self):
+    def __fennel_is_deleted__(self):
         if hasattr(self, META_FIELD):
             metadata = getattr(self, META_FIELD)
             return metadata.deleted
@@ -526,7 +526,7 @@ class Featureset:
         setattr(self, OWNER, owner)
         propogate_fennel_attributes(featureset_cls, self)
 
-    def is_deleted(self):
+    def __fennel_is_deleted__(self):
         if hasattr(self, META_FIELD):
             metadata = getattr(self, META_FIELD)
             return metadata.deleted

--- a/fennel/featuresets/test_featureset.py
+++ b/fennel/featuresets/test_featureset.py
@@ -569,6 +569,6 @@ def test_feature_is_deleted():
         age: int
         virtual: bool = F().meta(deleted=True)
 
-    assert not UserInfo.age.is_deleted()
-    assert not UserInfo.user_id.is_deleted()
-    assert UserInfo.virtual.is_deleted()
+    assert not UserInfo.age.__fennel_is_deleted__()
+    assert not UserInfo.user_id.__fennel_is_deleted__()
+    assert UserInfo.virtual.__fennel_is_deleted__()

--- a/fennel/testing/mock_client.py
+++ b/fennel/testing/mock_client.py
@@ -176,13 +176,15 @@ class MockClient(Client):
 
         if datasets is not None:
             datasets = [
-                dataset for dataset in datasets if not dataset.is_deleted()
+                dataset
+                for dataset in datasets
+                if not dataset.__fennel_is_deleted__()
             ]
         if featuresets is not None:
             featuresets = [
                 featureset
                 for featureset in featuresets
-                if not featureset.is_deleted()
+                if not featureset.__fennel_is_deleted__()
             ]
         if incremental:
             cur_datasets = self.get_datasets()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.75"
+version = "1.5.76"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rename `is_deleted` to `__fennel_is_deleted__` to prevent collisions with user fields in datasets, featuresets, and features.
> 
>   - **Behavior**:
>     - Rename `is_deleted` to `__fennel_is_deleted__` in `query_offline()` in `client.py` to prevent collision with user fields.
>     - Update `Dataset`, `Feature`, and `MockClient` classes to use `__fennel_is_deleted__()`.
>   - **Misc**:
>     - Update version to 1.5.76 in `pyproject.toml`.
>     - Add changelog entry for version 1.5.76 in `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=fennel-ai%2Fclient&utm_source=github&utm_medium=referral)<sup> for 32a7eb4130a5bd01fe2626e596fca353149ab16a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->