### PR TITLE
Add num dpus parameter to query offline API

### DIFF
--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## [1.5.53] - 2024-11-12
+- Add support for num_dpus parameter in offline query
 
 ## [1.5.77] - 2025-02-13
 - Revert join on optional fields in LHS

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [1.5.53] - 2024-11-12
+## [1.5.77] - 2024-11-12
 - Add support for num_dpus parameter in offline query
 
 ## [1.5.77] - 2025-02-13

--- a/fennel/CHANGELOG.md
+++ b/fennel/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [1.5.77] - 2024-11-12
+## [1.5.78] - 2024-11-12
 - Add support for num_dpus parameter in offline query
 
 ## [1.5.77] - 2025-02-13

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -459,6 +459,7 @@ class Client:
         feature_to_column_map: Optional[Dict[Feature, str]] = None,
         workflow: Optional[str] = None,
         use_v2: bool = True,
+        num_dpus: Optional[int] = None
     ) -> Dict[str, Any]:
         """Extract point in time correct values of output features.
 
@@ -497,6 +498,9 @@ class Client:
         workflow (Optional[str]): The name of the workflow associated with offline query.
             workflow param is equivalent to tagging (ex: fraud, finance etc.).
              If not provided, the "default" value will be used.
+
+        num_dpus (Optional[int]): Number of glue DPUs to use while executing the offline query.
+            We do not retry the job if it fails with the given DPUs
 
         Returns: Dict[str, Any]:
         ----------
@@ -625,6 +629,8 @@ class Client:
         }
         if workflow is not None:
             req["workflow"] = workflow
+        if num_dpus is not None:
+            req["num_dpus"] = num_dpus
         response = self._post_json(
             "{}/query_offline".format(
                 V1_API,

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -459,7 +459,7 @@ class Client:
         feature_to_column_map: Optional[Dict[Feature, str]] = None,
         workflow: Optional[str] = None,
         use_v2: bool = True,
-        num_dpus: Optional[int] = None
+        num_dpus: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Extract point in time correct values of output features.
 

--- a/fennel/client/client.py
+++ b/fennel/client/client.py
@@ -619,7 +619,7 @@ class Client:
                     ]
                 )
 
-        req = {
+        req: dict[str, Any] = {
             "input_features": input_feature_names,
             "output_features": output_feature_names,
             "input": extract_historical_input,

--- a/fennel/testing/mock_client.py
+++ b/fennel/testing/mock_client.py
@@ -312,6 +312,7 @@ class MockClient(Client):
         feature_to_column_map: Optional[Dict[Feature, str]] = None,
         workflow: Optional[str] = "default",
         use_v2: bool = False,
+        num_dpus: Optional[int] = None,
     ) -> Union[pd.DataFrame, pd.Series]:
         if input_dataframe is None:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fennel-ai"
-version = "1.5.77"
+version = "1.5.78"
 description = "The modern realtime feature engineering platform"
 authors = ["Fennel AI <developers@fennel.ai>"]
 packages = [{ include = "fennel" }]


### PR DESCRIPTION
Add `num_dpus` parameter to `query_offline()` in `client.py` and `mock_client.py` to specify Glue DPUs for offline queries.
